### PR TITLE
package.json: updated devDependencies of grunt-mocha-hack to ~0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt": "~0.4",
     "grunt-contrib-jshint": "~0.2",
     "grunt-contrib-watch": "~0.3.1",
-    "grunt-mocha-hack": "~0.0.4",
+    "grunt-mocha-hack": "~0.1.0",
     "chai": "~1.5.0",
     "request": "~2.16.6",
     "proxyquire": "~0.4.0",


### PR DESCRIPTION
Nach einem clean checkout und nach erfolgreichem `npm install` gab es folgende Fehlermeldung bei `npm test`:

```
Running "mocha-hack:all" (mocha-hack) task
Verifying property mocha-hack.all exists in config...OK
Files: test/access_test.js, test/activities/activitiesAPI_tests.js, test/activities/activities_store_tests.js, test/activities/activities_test.js, test/announcement_test.js, test/app_test.js, test/groups/groupsAPI_subscription_test.js, test/groups/groupsAPI_sympaStub_test.js, test/groups/groupsAPI_test.js, test/groups/groupsAndMembersAPI_test.js, test/groups/groups_test.js, test/groups/groupstore_test.js, test/members/member_object_test.js, test/members/memberstore_test.js, test/membersAPI_test.js, test/members_test.js, test/membertest_stubs.js, test/mongoConf.js, test/persistence_test.js, test/persistence_test_with_two_collections.js, test/securedByLogin_test.js, test/smoke_test.js, test/sympaTransformer_test.js
Warning: Arguments to path.resolve must be strings Use --force to continue.

Aborted due to warnings.
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

Ein Hinweis auf https://github.com/tutukin/grunt-proxy brachte mich darauf, eine neuere Version von grunt-mocha-hack zu testen, was die Tests durchlaufen ließ.
