### PR TITLE
Add blanket with grunt target 'coverage'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ public/test/
 version.jade
 
 test/tempbeans.json
+docs/generated

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,8 +35,20 @@ module.exports = function (grunt) {
     },
     qunit: {
       files: ['frontendtests/*.html']
+    },
+    exec: {
+      mkGenDocsDir: {
+        command: 'mkdir -p docs/generated'
+      },
+      coverage: {
+        command: 'mocha --require blanket --reporter html-cov --slow 0 test/**/*.js > docs/generated/coverage.html'
+      }
+    },
+    clean: {
+      tests: {
+        src: ["docs"]
+      }
     }
-
   });
 
   // These plugins provide necessary tasks.
@@ -44,9 +56,15 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-mocha-hack');
   grunt.loadNpmTasks('grunt-contrib-qunit');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-exec');
+
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'mocha-hack', 'qunit']);
+
+  // Coverage tasks
+  grunt.registerTask('coverage', ['clean', 'exec:mkGenDocsDir', 'exec:coverage']);
 
   // Travis-CI task
   grunt.registerTask('travis', ['default']);

--- a/package.json
+++ b/package.json
@@ -54,14 +54,23 @@
     "grunt-contrib-jshint": "~0.2",
     "grunt-contrib-watch": "~0.3.1",
     "grunt-mocha-hack": "~0.1.0",
+    "grunt-contrib-clean": "~0.4",
     "chai": "~1.5.0",
     "request": "~2.16.6",
     "supertest": "~0.5",
     "sinon": "~1.6.0",
-    "grunt-contrib-qunit": "0.2.1"
+    "grunt-contrib-qunit": "0.2.1",
+    "blanket": "~1.1.4",
+    "travis-cov": "~0.2"
   },
   "scripts": {
     "test": "grunt travis --verbose",
+    "blanket": {
+      "pattern": "//^((?!\/node_modules\/)(?!\/test\/).)*$/ig",
+      "onlyCwd": true,
+      "data-cover-flags": { "branchTracking": true }
+    },
+    "travis-cov": { "threshold": 67 },
     "prepublish": "sh ./prepublish.sh"
   }
 }


### PR DESCRIPTION
Add new grunt target 'coverage' to enable coverage reporting. This will generate a file docs/generated/coverage.html showing 61% currently.
