### PR TITLE
Versuch, das Phishing-Problem zu lösen

### DIFF
--- a/config/example(sendmail)-mailsender-config.json
+++ b/config/example(sendmail)-mailsender-config.json
@@ -1,5 +1,6 @@
 // to use this variant, strip "example(sendmail)-" from the filename and delete this comment
 {
   "transport": "sendmail",
-  "transport-options": {}
+  "transport-options": {},
+  "sender-address": "info@my-domain.org"
 }

--- a/config/example(smtp)-mailsender-config.json
+++ b/config/example(smtp)-mailsender-config.json
@@ -8,5 +8,6 @@
       "pass": ""
     },
     "debug": "true"
-  }
+  },
+  "sender-address": "info@my-domain.org"
 }

--- a/lib/mailsender/mailsenderAPI.js
+++ b/lib/mailsender/mailsenderAPI.js
@@ -10,7 +10,7 @@ var transport = nodemailer.createTransport(conf.get('transport'), conf.get('tran
 module.exports = {
   sendMail: function (message, callback) {
     var transportObject = {
-      from: 'info@softwerkskammer.org',
+      from: conf.get('sender-address'),
       replyTo: message.from,
       to: message.to,
       cc: message.cc,


### PR DESCRIPTION
EMails, die die Plattform verschickt, bekommen nun einen Softwerkskammer-Absender. Der echte Absender steht im Reply-To. Ich hoffe, das behebt die Phishing-Meldung, ohne Nachteile zu haben.
