### PR TITLE
Fixed typo in text - Email into E-Mail

### DIFF
--- a/frontendtests/editgroups.html
+++ b/frontendtests/editgroups.html
@@ -37,7 +37,7 @@
                         <input id="description" type="text" name="description" class="input-block-level input-xlarge"/>
                     </div>
                     <div class="control-group">
-                        <label for="emailPrefix" class="control-label">Präfix für Emails:</label>
+                        <label for="emailPrefix" class="control-label">Präfix für E-Mails:</label>
                         <input id="emailPrefix" type="text" name="emailPrefix" class="input-block-level input-xlarge"/>
                     </div>
                     <div class="control-group">

--- a/lib/commons/validation.js
+++ b/lib/commons/validation.js
@@ -22,8 +22,8 @@ module.exports = {
     validator.check(member.nickname, 'Nickname muss mindestens 2 Zeichen enthalten.').len(2);
     validator.check(member.firstname, 'Vorname ist ein Pflichtfeld.').notEmpty();
     validator.check(member.lastname, 'Nachname ist ein Pflichtfeld.').notEmpty();
-    validator.check(member.email, 'Email ist ein Pflichtfeld.').notEmpty();
-    validator.check(member.email, 'Email muss gültig sein.').isEmail();
+    validator.check(member.email, 'E-Mail ist ein Pflichtfeld.').notEmpty();
+    validator.check(member.email, 'E-Mail muss gültig sein.').isEmail();
     validator.check(member.location, 'Ort / Region ist ein Pflichtfeld.').notEmpty();
     validator.check(member.reference, 'Wie ich von... ist ein Pflichtfeld.').notEmpty();
     validator.check(member.profession, 'Beruf ist ein Pflichtfeld.').notEmpty();
@@ -35,9 +35,9 @@ module.exports = {
     validator.check(group.id, 'Name ist ein Pflichtfeld.').notEmpty();
     validator.check(group.id, 'Name muss mindestens 2 und höchstens 20 Zeichen enthalten.').len(2, 20);
     validator.check(group.id, 'Name darf nur Buchstaben, Zahlen, Bindestrich und Unterstrich enthalten.').regex(/^[\w-]+$/i);
-    validator.check(group.emailPrefix, 'Präfix für Emails ist ein Pflichtfeld.').notEmpty();
-    validator.check(group.emailPrefix, 'Präfix für Emails muss mindestens 5 und höchstens 15 Zeichen enthalten.').len(5, 15);
-    validator.check(group.emailPrefix, 'Präfix für Emails darf nur Zahlen, Buchstaben, Leerzeichen und Bindestriche enthalten.').regex(/^[a-z0-9 -]+$/i);
+    validator.check(group.emailPrefix, 'Präfix für E-Mails ist ein Pflichtfeld.').notEmpty();
+    validator.check(group.emailPrefix, 'Präfix für E-Mails muss mindestens 5 und höchstens 15 Zeichen enthalten.').len(5, 15);
+    validator.check(group.emailPrefix, 'Präfix für E-Mails darf nur Zahlen, Buchstaben, Leerzeichen und Bindestriche enthalten.').regex(/^[a-z0-9 -]+$/i);
     validator.check(group.longName, 'Titel ist ein Pflichtfeld.').notEmpty();
     validator.check(group.description, 'Beschreibung ist ein Pflichtfeld.').notEmpty();
     validator.check(group.type, 'Gruppenart ist ein Pflichtfeld.').notEmpty();

--- a/lib/groups/views/edit.jade
+++ b/lib/groups/views/edit.jade
@@ -29,11 +29,11 @@ block content
             mixin textReadonly('id', 'Name', group)
           else
             mixin text('id', 'Name', group, 'Die Adresse, unter der die Gruppe "@softwerkskammer.org" erreichbar ist.')
-          mixin text('longName', 'Titel', group, 'Anzeigetext innerhalb der Site, ist auch Realname für Emails')
+          mixin text('longName', 'Titel', group, 'Anzeigetext innerhalb der Site, ist auch Realname für E-Mails')
           if (group.isValid())
-            mixin textReadonly('emailPrefix', 'Präfix für Email-Subjects', group)
+            mixin textReadonly('emailPrefix', 'Präfix für E-Mail-Subjects', group)
           else
-            mixin text('emailPrefix', 'Präfix für Email-Subjects', group, 'steht innerhalb [] vor dem Subject in gesendeten Emails')
+            mixin text('emailPrefix', 'Präfix für E-Mail-Subjects', group, 'steht innerhalb [] vor dem Subject in gesendeten E-Mails')
           .control-group
             label.control-label(for="type") Gruppenart:
             select#type.input-block-level.input-xlarge(name="type")

--- a/lib/site/views/help.jade
+++ b/lib/site/views/help.jade
@@ -14,13 +14,13 @@ block content
       h3 Profil
       dl
         dt Wie kann ich ein Profilbild hinterlegen?
-        dd Funktioniert aktuell nur über Gravatar. Wenn Deine hinterlegte Emailadresse bei Gravatar ein Bild hinterlegt hat, zeigen wir das. 
-        dt Kann ich mehr als eine Emailadresse hinterlegen?
+        dd Funktioniert aktuell nur über Gravatar. Wenn Deine hinterlegte E-Mail-Adresse bei Gravatar ein Bild hinterlegt hat, zeigen wir das. 
+        dt Kann ich mehr als eine E-Mail-Adresse hinterlegen?
         dd Nein. Uns ist klar, dass dies eventuell beim Posten an eine Gruppe unangenehm ist. Leider ist dies mit unserem Listen-Backend nicht  
           | ganz einfach, mehrere Adressen für einen User zu verwalten. 
         dt Kann ich meinen Nickname ändern?
         dd Ja, das geht.
-        dt Kann ich meine Emailadresse ändern?
+        dt Kann ich meine E-Mail-Adresse ändern?
         dd Ja, das geht.
         dt Kann ich meine Authentifizierungsmethode ändern?
         dd Nein, aktuell nicht.
@@ -28,11 +28,11 @@ block content
       h3 Gruppen
       dl
         dt Was hat es mit den Gruppen auf sich?
-        dd Die Gruppen repräsentieren regionale oder thematische Einheiten und sind gleichzeitig Emaillisten 
+        dd Die Gruppen repräsentieren regionale oder thematische Einheiten und sind gleichzeitig E-Mail-Listen 
         dt Warum erhalte ich immer Mails, wenn ich einer Gruppe beitrete oder austrete?
         dd Das liegt daran, dass im Hintergrund ein "ganz normaler" Listenserver die Listen verwaltet. Dieser ist entsprechend
           | konfiguriert.
-        dt Kann ich aus einer Gruppe über Email austreten? 
+        dt Kann ich aus einer Gruppe über E-Mail austreten? 
         dd Ja, das geht.
   .row-fluid
     .span6
@@ -40,8 +40,8 @@ block content
       dl
         dt Sichtbarkeit der Daten
         dd Grundsätzlich sind Mitgliederdaten nur für registrierte Mitglieder sichtbar.
-        dt Sichtbarkeit von Emailadressen
-        dd Emailadressen sind nur für Administratoren sichtbar. Sollte dies nicht so sein, ist das ein Bug
+        dt Sichtbarkeit von E-Mail-Adressen
+        dd E-Mail-Adressen sind nur für Administratoren sichtbar. Sollte dies nicht so sein, ist das ein Bug
         dt Fehlerfreiheit
         dd Die Software ist Open Source und mit Sicherheit voller Fehler. Auch, was den Datenschutz betrifft.
         dt Cookies, Tracking etc.

--- a/public/clientscripts/check-groupform.js
+++ b/public/clientscripts/check-groupform.js
@@ -9,12 +9,12 @@ var initValidator = function () {
   $.validator.addMethod("alnumdashblank", function(value, element)
                         {
                           return this.optional(element) || /^[a-z0-9 -]+$/i.test(value);
-                        }, "Präfix für Emails darf nur Zahlen, Buchstaben, Leerzeichen und Bindestriche enthalten.");
+                        }, "Präfix für E-Mails darf nur Zahlen, Buchstaben, Leerzeichen und Bindestriche enthalten.");
 
   $.validator.addMethod("alnumdashunderscore", function(value, element)
                         {
                           return this.optional(element) || /^[a-z0-9_-]+$/i.test(value);
-                        }, "Email-Adresse darf nur Zahlen, Buchstaben, Bindestrich und Unterstrich enthalten.");
+                        }, "E-Mail-Adresse darf nur Zahlen, Buchstaben, Bindestrich und Unterstrich enthalten.");
 
   groups_validator = $("#groupform").validate({
     rules: {


### PR DESCRIPTION
Fixed typo in text - Email into E-Mail

"E-Mail, die oder das" (Source: http://www.duden.de/rechtschreibung/E_Mail)
