### PR TITLE
add "start" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "grunt-exec": "~0.4.0"
   },
   "scripts": {
+    "start": "node start",
     "test": "grunt travis --verbose",
     "blanket": {
       "pattern": "//^((?!\/node_modules\/)(?!\/test\/).)*$/ig",


### PR DESCRIPTION
this allows users to start using the standard "npm start" command and acts as
documentation
