### PR TITLE
Nicknames in URL encodieren

### DIFF
--- a/views/layoutComponents.jade
+++ b/views/layoutComponents.jade
@@ -31,7 +31,7 @@ mixin loginMenu
             i.icon-info-sign
             b.caret
           ul.dropdown-menu
-            li: a(href="/members/edit/#{user.member.nickname}")
+            li: a(href="/members/edit/#{encodeURIComponent(user.member.nickname)}")
               i.icon-edit
               | &nbsp;Profil bearbeiten
             li: a(href="/auth/logout")


### PR DESCRIPTION
Da wir Sonderzeichen in Nickname zulassen sollten sie in URL encodiert werden.

Das behebt das Problem, dass ich am Freitag mit dem Zugriff auf meine Edit Seite hatte.
