### PR TITLE
remove icon-spin style from globe

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -57,10 +57,10 @@ html
           ul.nav.navbar-nav
             li#announcements: a(href="/announcements")
               span.hidden-sm
-                i.icon-globe.icon-spin
+                i.icon-globe
                 | &nbsp;Nachrichten
               span.visible-sm
-                i.icon-globe.icon-spin
+                i.icon-globe
             li#activities: a(href="/activities/upcoming")
               span.hidden-sm
                 i.icon-calendar


### PR DESCRIPTION
closes #416

Habe icon-spin nur im jade file entfernt, da es im css wie ich verstanden habe von bootstrap kommt.
Nicht getestet, da lokal das noetige node.js setup fehlt.
