### PR TITLE
saving objects now uses update instead of remove-insert

### DIFF
--- a/lib/persistence/persistence.js
+++ b/lib/persistence/persistence.js
@@ -60,12 +60,9 @@ module.exports = function (collectionName) {
       performInDB(function (err, db) {
         if (err) { return callback(err); }
         var collection = db.collection(collectionName);
-        collection.remove({id: object.id}, {safe: true}, function (err) {
+        collection.update({id: object.id}, object, {upsert: true}, function (err, result) {
           if (err) { return callback(err); }
-          collection.insert(object, {safe: true}, function (err, result) {
-            if (err) { return callback(err); }
-            callback(null, result);
-          });
+          callback(null, result);
         });
       });
     },


### PR DESCRIPTION
- external behavior is the same internally
- exceptions occurring between the two calls (remove/insert) now simply cannot happen anymore.
