### PR TITLE
Revert "Hotfix: --follow does not show anything when there was no rename...

### DIFF
--- a/lib/wiki/gitmech.js
+++ b/lib/wiki/gitmech.js
@@ -134,7 +134,7 @@ module.exports = {
   },
 
   log: function (path, version, howMany, callback) {
-    gitExec(['log', '-' + howMany, '--no-notes', '--pretty=format:%h%n%H%n%an%n%ai%n%s', version, '--', path], function (err, data) {
+    gitExec(['log', '-' + howMany, '--no-notes', '--follow', '--pretty=format:%h%n%H%n%an%n%ai%n%s', version, '--', path], function (err, data) {
       var logdata = data ? data.toString().split('\n') : [];
       var group;
       var metadata = [];


### PR DESCRIPTION
I installed the latest version of git, and now --follow works as intended.
