### PR TITLE
specify date format of sympa archives to be like:... 

### DIFF
--- a/lib/mailarchive/importMails.js
+++ b/lib/mailarchive/importMails.js
@@ -12,7 +12,7 @@ var crypto = require('crypto');
 module.exports = function (file, group, done) {
   function date(parsedObject) {
     if (fieldHelpers.isFilled(parsedObject.headers.date)) {
-      return moment(parsedObject.headers.date);
+      return moment(parsedObject.headers.date, 'ddd, DD MMM YYYY HH:mm:ss ZZ', 'en');
     }
     return moment();
   }


### PR DESCRIPTION
"Mon, 25 Mar 2013 21:14:14 +0100",

thereby eliminating the warning of "moment.js"
