### PR TITLE
Upgrade to moment-timezone-0.0.6

### DIFF
--- a/lib/commons/fieldHelpers.js
+++ b/lib/commons/fieldHelpers.js
@@ -4,30 +4,8 @@ var _s = require('underscore.string');
 var crypto = require('crypto');
 var moment = require('moment-timezone');
 
-function parseAssumingUtc(dateString, timeString) {
-  var timeStringOrDefault = timeString || '00:00';
-  return moment.utc(dateString + ' ' + timeStringOrDefault, 'D.M.YYYY H:m');
-}
-
 function leadingZeroFor(number) {
   return number < 10 ? '0' : '';
-}
-
-// Converts `sourceMoment` into a moment in `timezone` with the same local time.
-// Example: '2013-01-02T03:04:00+00:00' will result in '2013-01-02T03:04:00+01:00'
-//          when used with timezone 'Europe/Berlin'.
-// Eventually, moment-timezone should be able to do this for us:
-// <https://github.com/moment/moment-timezone/issues/11>
-function toMomentInTimezone(sourceMoment, timezone) {
-  var year = sourceMoment.year();
-  var month = sourceMoment.month() + 1; // zero-based month representation!
-  var date = sourceMoment.date();
-  var result = moment.tz(year + '-' + leadingZeroFor(month) + month + '-' + leadingZeroFor(date) + date + ' 12:00', timezone);
-  result.hour(sourceMoment.hour());
-  result.minute(sourceMoment.minute());
-  result.second(sourceMoment.second());
-  result.millisecond(sourceMoment.millisecond());
-  return result;
 }
 
 module.exports = {
@@ -101,8 +79,8 @@ module.exports = {
 
   parseToMomentUsingTimezone: function (dateString, timeString, timezoneName) {
     if (dateString) {
-      var utcBasedMoment = parseAssumingUtc(dateString, timeString);
-      return toMomentInTimezone(utcBasedMoment, timezoneName);
+      var timeStringOrDefault = timeString || '00:00';
+      return moment.tz(dateString + ' ' + timeStringOrDefault, 'D.M.YYYY H:m', timezoneName);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "2.4.1",
     "mailparser": "~0.4",
     "marked": "~0.3",
-    "moment-timezone": "0.0.3",
+    "moment-timezone": "0.0.6",
     "mongodb": "~1.4",
     "morgan": "~1.0",
     "nodemailer": "~0.6",

--- a/test/commons/fieldHelpers_test.js
+++ b/test/commons/fieldHelpers_test.js
@@ -218,4 +218,11 @@ describe('parseToMomentUsingTimezone function', function () {
     expect(result).to.be(undefined);
   });
 
+  it('returns unix timestamps with correct offsets', function () {
+    var berlinMoment = fieldHelpers.parseToMomentUsingTimezone('2.8.2013', '12:34:56', 'Europe/Berlin');
+    var utcMoment = fieldHelpers.parseToMomentUsingTimezone('2.8.2013', '12:34:56', 'UTC');
+    var twoHoursInSeconds = 2 * 60 * 60;
+    expect(berlinMoment.unix() + twoHoursInSeconds).to.equal(utcMoment.unix());
+  });
+
 });

--- a/test/moment/moment_timezone_assumptions.js
+++ b/test/moment/moment_timezone_assumptions.js
@@ -23,16 +23,16 @@ describe('moment-timezone', function () {
     expect(utcMoment.unix()).to.equal(berlinMoment.unix());
   });
 
-  it('shifts the time (and thus possibly the date) when switching from winter to summer', function () {
+  it('does not shift the time when switching from winter to summer anymore', function () {
     var result = moment.tz('2013-11-30 23:30', 'Europe/Berlin');
     result.month(7); // set to August (!)
-    expect(result.format(), 'Resulting date is 31st, not 30th!').to.equal('2013-08-31T00:30:00+02:00');
+    expect(result.format(), 'Resulting date is 30th').to.equal('2013-08-30T23:30:00+02:00');
   });
 
-  it('time shift is especially nasty when it shifts the month after setting the month', function () {
+  it('does not shift the month after setting the month anymore', function () {
     var result = moment.tz('2013-01-31 23:30', 'Europe/Berlin');
     result.month(7); // set to August (!)
-    expect(result.format(), 'Resulting month is September, not August!').to.equal('2013-09-01T00:30:00+02:00');
+    expect(result.format(), 'Resulting month is August').to.equal('2013-08-31T23:30:00+02:00');
   });
 
 });


### PR DESCRIPTION
- Remove workaround in fieldHelpers.js to allow parsing dates assuming
  a certain timezone as moment.tz() supports that now.
- Adjust assumptions about moment-timezone which seems to handle
  crossing timezone changing points better now.

This is a follow-up on #329 made possible by moment/moment-timezone#11 having been fixed.
