### PR TITLE
Creating a new SoCraTes member now also creates a participant.

### DIFF
--- a/Gruntfile-SoCraTes.js
+++ b/Gruntfile-SoCraTes.js
@@ -4,6 +4,14 @@ module.exports = function (grunt) {
   // set up common objects for jslint
   var jsLintStandardOptions = {edition: 'latest', errorsOnly: true, failOnError: true};
 
+  var serverDirectives = function () {
+    return {indent: 2, node: true, nomen: true, todo: true, unparam: true, vars: true};
+  };
+  var jsLintServerDirectives = serverDirectives();
+  var jsLintServerTestDirectives = serverDirectives();
+  jsLintServerTestDirectives.ass = true;
+  jsLintServerTestDirectives.predef = ['afterEach', 'after', 'beforeEach', 'before', 'describe', 'it'];
+
   // filesets for uglify
   var files = {
     'socrates/public/clientscripts/global.js': [
@@ -82,14 +90,15 @@ module.exports = function (grunt) {
           'socrates/*.js',
           'socrates/lib/**/*.js'
         ],
-        directives: {
-          indent: 2,
-          node: true,
-          nomen: true,
-          todo: true,
-          unparam: true,
-          vars: true
-        },
+        directives: jsLintServerDirectives,
+        options: jsLintStandardOptions
+      },
+      servertests: {
+        src: [
+          'socrates/test/**/*.js',
+          'socrates/testutil/**/*.js'
+        ],
+        directives: jsLintServerTestDirectives,
         options: jsLintStandardOptions
       },
       client: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -349,8 +349,5 @@ module.exports = function (grunt) {
   // Default task.
   grunt.registerTask('default', ['tests', 'uglify:development_en']);
 
-  // Travis-CI task
-  grunt.registerTask('travis', ['default']);
-
   grunt.registerTask('deploy_production', ['prepare', 'uglify:production_de', 'uglify:production_en']);
 };

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "scripts": {
     "start": "node softwerkskammer/start",
-    "test": "grunt tests",
+    "test": "grunt tests; grunt --gruntfile Gruntfile-SoCraTes.js tests",
     "prepublish": "sh softwerkskammer/prepublish.sh"
   }
 }

--- a/socrates/lib/authentication/index.js
+++ b/socrates/lib/authentication/index.js
@@ -53,7 +53,7 @@ app.get('/loggedIn', function (req, res, next) {
           res.redirect(returnTo);
         });
       }
-      res.redirect('/registration/editmember');
+      res.redirect('/members/edit');
     });
   });
 });

--- a/socrates/lib/members/index.js
+++ b/socrates/lib/members/index.js
@@ -23,13 +23,6 @@ app.get('/checkemail', function (req, res) {
   misc.validate(req.query.email, req.query.previousEmail, membersService.isValidEmail, res.end);
 });
 
-app.get('/:nickname', function (req, res, next) {
-  participantService.getMemberIfParticipantExists(req.params.nickname, function (err, member) {
-    if (err || !member) { return next(err); }
-    res.render('get', {member: member});
-  });
-});
-
 app.get('/edit', function (req, res) {
   var member = req.user.member || new Member().initFromSessionUser(req.user, true);
   res.render('edit', {member: member});
@@ -81,5 +74,12 @@ app.post('/submit', function (req, res, next) {
 
 });
 
+
+app.get('/:nickname', function (req, res, next) {
+  participantService.getMemberIfParticipantExists(req.params.nickname, function (err, member) {
+    if (err || !member) { return next(err); }
+    res.render('get', {member: member});
+  });
+});
 
 module.exports = app;

--- a/socrates/lib/members/index.js
+++ b/socrates/lib/members/index.js
@@ -44,10 +44,13 @@ app.post('/submit', function (req, res, next) {
 
     return groupsAndMembersService.updateAndSaveSubmittedMemberWithoutSubscriptions(req.user, req.body, res.locals.accessrights, notifyNewMemberRegistration, function (err, nickname) {
       if (err) { return next(err); }
-      if (nickname) {
-        statusmessage.successMessage('message.title.save_successful', 'message.content.members.saved').putIntoSession(req);
-      }
-      return res.redirect('/');
+      participantService.createParticipantIfNecessaryFor(req.user.member.id(), function (err) {
+        if (err) { return next(err); }
+        if (nickname) {
+          statusmessage.successMessage('message.title.save_successful', 'message.content.members.saved').putIntoSession(req);
+        }
+        return res.redirect('/');
+      });
     });
   }
 
@@ -77,5 +80,6 @@ app.post('/submit', function (req, res, next) {
   );
 
 });
+
 
 module.exports = app;

--- a/socrates/lib/members/index.js
+++ b/socrates/lib/members/index.js
@@ -4,6 +4,7 @@ var beans = require('simple-configure').get('beans');
 var misc = beans.get('misc');
 var membersService = beans.get('membersService');
 var participantService = beans.get('participantService');
+var Member = beans.get('member');
 
 var app = misc.expressAppIn(__dirname);
 
@@ -20,6 +21,11 @@ app.get('/:nickname', function (req, res, next) {
     if (err || !member) { return next(err); }
     res.render('get', {member: member});
   });
+});
+
+app.get('/edit', function (req, res) {
+  var member = req.user.member || new Member().initFromSessionUser(req.user, true);
+  res.render('edit', {member: member});
 });
 
 module.exports = app;

--- a/socrates/lib/members/index.js
+++ b/socrates/lib/members/index.js
@@ -1,10 +1,17 @@
 'use strict';
 
+var _ = require('lodash');
+var async = require('async');
+
 var beans = require('simple-configure').get('beans');
 var misc = beans.get('misc');
 var membersService = beans.get('membersService');
 var participantService = beans.get('participantService');
 var Member = beans.get('member');
+var notifications = beans.get('notifications');
+var groupsAndMembersService = beans.get('groupsAndMembersService');
+var statusmessage = beans.get('statusmessage');
+var validation = beans.get('validation');
 
 var app = misc.expressAppIn(__dirname);
 
@@ -26,6 +33,49 @@ app.get('/:nickname', function (req, res, next) {
 app.get('/edit', function (req, res) {
   var member = req.user.member || new Member().initFromSessionUser(req.user, true);
   res.render('edit', {member: member});
+});
+
+app.post('/submit', function (req, res, next) {
+  function memberSubmitted(req, res, next) {
+    function notifyNewMemberRegistration(member, subscriptions) {
+      // must be done here, not in Service to avoid circular deps
+      return notifications.newMemberRegistered(member, subscriptions);
+    }
+
+    return groupsAndMembersService.updateAndSaveSubmittedMemberWithoutSubscriptions(req.user, req.body, res.locals.accessrights, notifyNewMemberRegistration, function (err, nickname) {
+      if (err) { return next(err); }
+      if (nickname) {
+        statusmessage.successMessage('message.title.save_successful', 'message.content.members.saved').putIntoSession(req);
+      }
+      return res.redirect('/');
+    });
+  }
+
+  async.parallel(
+    [
+      function (callback) {
+        // we need this helper function (in order to have a closure?!)
+        var validityChecker = function (nickname, callback) { membersService.isValidNickname(nickname, callback); };
+        validation.checkValidity(req.body.previousNickname, req.body.nickname, validityChecker, 'validation.nickname_not_available', callback);
+      },
+      function (callback) {
+        // we need this helper function (in order to have a closure?!)
+        var validityChecker = function (email, callback) { membersService.isValidEmail(email, callback); };
+        validation.checkValidity(req.body.previousEmail, req.body.email, validityChecker, 'validation.duplicate_email', callback);
+      },
+      function (callback) {
+        return callback(null, validation.isValidForSoCraTesMember(req.body));
+      }
+    ],
+    function (err, errorMessages) {
+      var realErrors = _.filter(_.flatten(errorMessages), function (message) { return !!message; });
+      if (realErrors.length === 0) {
+        return memberSubmitted(req, res, next);
+      }
+      return res.render('../../../views/errorPages/validationError', {errors: realErrors});
+    }
+  );
+
 });
 
 module.exports = app;

--- a/socrates/lib/members/views/edit.jade
+++ b/socrates/lib/members/views/edit.jade
@@ -1,5 +1,5 @@
 include  ../../../views/formComponents
-include userinfoform
+include ../../registration/views/userinfoform
 
 extends ../../../views/simpleLayout
 

--- a/socrates/lib/members/views/edit.jade
+++ b/socrates/lib/members/views/edit.jade
@@ -13,7 +13,7 @@ block title
     | #{t('members.create')}
 
 block content
-  form#memberform.relaxed(action='/registration/submitmember',method='post')
+  form#memberform.relaxed(action='/members/submit',method='post')
     +csrf
     +memberinfoform(member, 'members.edit_preregistration')
     +memberSubmitButtons

--- a/socrates/lib/middleware/redirectRuleForNewUser.js
+++ b/socrates/lib/middleware/redirectRuleForNewUser.js
@@ -2,11 +2,11 @@
 
 module.exports = function redirectRuleForNewUser(req, res, next) {
   function proceed() {
-    return (/\/registration\/editmember|\/registration\/submitmember|\/auth\/logout|clientscripts|stylesheets|img|fonts|checknickname|checkemail/).test(req.originalUrl);
+    return (/\/members\/edit|\/registration\/submitmember|\/auth\/logout|clientscripts|stylesheets|img|fonts|checknickname|checkemail/).test(req.originalUrl);
   }
 
   if (req.user && !req.user.member && !proceed()) {
-    return res.redirect('/registration/editmember');
+    return res.redirect('/members/edit');
   }
   next();
 };

--- a/socrates/lib/middleware/redirectRuleForNewUser.js
+++ b/socrates/lib/middleware/redirectRuleForNewUser.js
@@ -2,7 +2,7 @@
 
 module.exports = function redirectRuleForNewUser(req, res, next) {
   function proceed() {
-    return (/\/members\/edit|\/registration\/submitmember|\/auth\/logout|clientscripts|stylesheets|img|fonts|checknickname|checkemail/).test(req.originalUrl);
+    return (/\/members\/edit|\/members\/submit|\/auth\/logout|clientscripts|stylesheets|img|fonts|checknickname|checkemail/).test(req.originalUrl);
   }
 
   if (req.user && !req.user.member && !proceed()) {

--- a/socrates/lib/registration/index.js
+++ b/socrates/lib/registration/index.js
@@ -1,15 +1,9 @@
 'use strict';
 var moment = require('moment-timezone');
-var async = require('async');
-var _ = require('lodash');
 
 var beans = require('simple-configure').get('beans');
 var misc = beans.get('misc');
 var membersService = beans.get('membersService');
-var notifications = beans.get('notifications');
-var validation = beans.get('validation');
-var statusmessage = beans.get('statusmessage');
-var groupsAndMembersService = beans.get('groupsAndMembersService');
 var mailsenderService = beans.get('mailsenderService');
 
 var app = misc.expressAppIn(__dirname);
@@ -37,50 +31,6 @@ app.get('/participate', function (req, res) {
 app.post('/participate', function (req, res) {
   console.log(req.body);
   res.redirect('participate');
-});
-
-app.post('/submitmember', function (req, res, next) {
-  function memberSubmitted(req, res, next) {
-    function notifyNewMemberRegistration(member, subscriptions) {
-      // must be done here, not in Service to avoid circular deps
-      return notifications.newMemberRegistered(member, subscriptions);
-    }
-
-    return groupsAndMembersService.updateAndSaveSubmittedMemberWithoutSubscriptions(req.user, req.body, res.locals.accessrights, notifyNewMemberRegistration, function (err, nickname) {
-      if (err) { return next(err); }
-      if (nickname) {
-        statusmessage.successMessage('message.title.save_successful', 'message.content.members.saved').putIntoSession(req);
-        return res.redirect('/');
-      }
-      return res.redirect('/');
-    });
-  }
-
-  async.parallel(
-    [
-      function (callback) {
-        // we need this helper function (in order to have a closure?!)
-        var validityChecker = function (nickname, callback) { membersService.isValidNickname(nickname, callback); };
-        validation.checkValidity(req.body.previousNickname, req.body.nickname, validityChecker, 'validation.nickname_not_available', callback);
-      },
-      function (callback) {
-        // we need this helper function (in order to have a closure?!)
-        var validityChecker = function (email, callback) { membersService.isValidEmail(email, callback); };
-        validation.checkValidity(req.body.previousEmail, req.body.email, validityChecker, 'validation.duplicate_email', callback);
-      },
-      function (callback) {
-        return callback(null, validation.isValidForSoCraTesMember(req.body));
-      }
-    ],
-    function (err, errorMessages) {
-      var realErrors = _.filter(_.flatten(errorMessages), function (message) { return !!message; });
-      if (realErrors.length === 0) {
-        return memberSubmitted(req, res, next);
-      }
-      return res.render('../../../views/errorPages/validationError', {errors: realErrors});
-    }
-  );
-
 });
 
 app.get('/resign', function (req, res) {

--- a/socrates/lib/registration/index.js
+++ b/socrates/lib/registration/index.js
@@ -9,7 +9,6 @@ var membersService = beans.get('membersService');
 var notifications = beans.get('notifications');
 var validation = beans.get('validation');
 var statusmessage = beans.get('statusmessage');
-var Member = beans.get('member');
 var groupsAndMembersService = beans.get('groupsAndMembersService');
 var mailsenderService = beans.get('mailsenderService');
 
@@ -38,11 +37,6 @@ app.get('/participate', function (req, res) {
 app.post('/participate', function (req, res) {
   console.log(req.body);
   res.redirect('participate');
-});
-
-app.get('/editmember', function (req, res) {
-  var member = req.user.member || new Member().initFromSessionUser(req.user, true);
-  res.render('editmember', {member: member});
 });
 
 app.post('/submitmember', function (req, res, next) {

--- a/socrates/lib/registration/views/userinfoform.jade
+++ b/socrates/lib/registration/views/userinfoform.jade
@@ -4,16 +4,13 @@ mixin memberinfoform(member, newmember_text)
       legend
         h4 #{t('members.personal_data')}
       .well
-        - if (accessrights.isRegistered())
-          - if (member.socratesOnly())
-            p.
-              #{t('members.edit_socrates_only')}
-          - else
-            p.
-              #{t('members.edit_socrates_softwerkskammer')}
-        - else
-          p.
-            #{t(newmember_text)}
+        if (accessrights.isRegistered())
+          if (member.socratesOnly())
+            p #{t('members.edit_socrates_only')}
+          else
+            p #{t('members.edit_socrates_softwerkskammer')}
+        else
+          p #{t(newmember_text)}
 
   .row
     .col-sm-6

--- a/socrates/lib/site/views/index.jade
+++ b/socrates/lib/site/views/index.jade
@@ -67,12 +67,12 @@ block content
               h5
                 +extlink('http://www.codefreeze.fi/', 'CodeFreeze')
                 br
-                small 3 - 4 Feb, Kiilopää
+                small 3 - 4 Feb, Kiilopää, Finland
             .col-sm-6
               h5
-                +extlink('http://socrates.shiki.es/', 'SoCraTes Canaries 2015')
+                +extlink('http://socrates-conference.es/', 'SoCraTes Canaries 2015')
                 br
-                small 26 Feb - 1 Mar, Teneriffa
+                small 26 Feb - 1 Mar, Tenerife
             .col-sm-6
               h5
                 +extlink('http://2015.itakeunconf.com/', 'I T.A.K.E. Unconference')

--- a/socrates/test/members/members_test.js
+++ b/socrates/test/members/members_test.js
@@ -4,48 +4,54 @@ var request = require('supertest');
 var sinon = require('sinon').sandbox.create();
 
 var beans = require('../../testutil/configureForTest').get('beans');
+var userWithoutMember = require('../../testutil/userWithoutMember');
+var accessrights = beans.get('accessrights');
 var memberstore = beans.get('memberstore');
 var participantstore = beans.get('participantstore');
 var Member = beans.get('member');
 var Participant = beans.get('participant');
 
-var createApp = require('../../../softwerkskammer/testutil/testHelper')('socratesMembersApp').createApp;
+var createApp = require('../../testutil/testHelper')('socratesMembersApp').createApp;
 
 describe('SoCraTes members application', function () {
-  var appWithMember;
+  var appWithoutMember;
+  var appWithSoftwerkskammerMember;
+  var appWithSocratesMember;
+  var softwerkskammerMember;
+  var socratesMember;
+  var softwerkskammerParticipant;
+  var socratesParticipant;
 
   before(function () {
-    appWithMember = request(createApp('memberId'));
-  });
-
-  var member1;
-  var member2;
-  var participant1;
-  var participant2;
-
-  beforeEach(function () {
-    member1 = new Member({
+    softwerkskammerMember = new Member({
       id: 'memberId',
       nickname: 'hada',
       email: 'a@b.c',
       site: 'http://my.blog',
       firstname: 'Hans',
       lastname: 'Dampf',
-      authentications: []
+      authentications: [],
+      socratesOnly: false
     });
-    participant1 = new Participant({id: 'memberId'});
+    softwerkskammerParticipant = new Participant({id: 'memberId'});
 
-    member2 = new Member({
+    socratesMember = new Member({
       id: 'memberId2',
       nickname: 'nini',
       email: 'x@y.com',
       site: 'http://my.blog',
       firstname: 'Petra',
       lastname: 'Meier',
-      authentications: []
+      authentications: [],
+      socratesOnly: true
     });
-    participant2 = new Participant({id: 'memberId2'});
+    socratesParticipant = new Participant({id: 'memberId2'});
+
+    appWithoutMember = request(createApp({middlewares: [userWithoutMember]}));
+    appWithSoftwerkskammerMember = request(createApp({member: softwerkskammerMember}));
+    appWithSocratesMember = request(createApp({member: socratesMember}));
   });
+
 
   afterEach(function () {
     sinon.restore();
@@ -56,25 +62,25 @@ describe('SoCraTes members application', function () {
     it('gives a 404 if there is no matching member in the database', function (done) {
       sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null); });
 
-      appWithMember
+      appWithSoftwerkskammerMember
         .get('/hada')
         .expect(404, done);
     });
 
     it('gives a 404 if there is a member but no matching participant in the database', function (done) {
-      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member1); });
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, softwerkskammerMember); });
       sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null); });
 
-      appWithMember
+      appWithSoftwerkskammerMember
         .get('/hada')
         .expect(404, done);
     });
 
     it('shows the participant\'s own page', function (done) {
-      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member1); });
-      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, participant1); });
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, softwerkskammerMember); });
+      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, softwerkskammerParticipant); });
 
-      appWithMember
+      appWithSoftwerkskammerMember
         .get('/hada')
         .expect(200)
         .expect(/First name:<\/strong> Hans/)
@@ -82,15 +88,44 @@ describe('SoCraTes members application', function () {
     });
 
     it('shows a different participant\'s page', function (done) {
-      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member2); });
-      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, participant2); });
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, socratesMember); });
+      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, socratesParticipant); });
 
-      appWithMember
+      appWithSoftwerkskammerMember
         .get('/nini')
         .expect(200)
         .expect(/First name:<\/strong> Petra/)
         .expect(/Last name:<\/strong> Meier/, done);
     });
+
+  });
+
+  describe('editing a member page', function () {
+
+    it('allows somebody who is neither member nor participant to create his account', function (done) {
+      appWithoutMember
+        .get('/edit')
+        .expect(200)
+        .expect(/In order to keep you informed about the SoCraTes conference, we need you to provide us with the following information\. Please fill in all mandatory fields\./, done);
+    });
+
+    it('allows a SoCraTes-only member to edit his page', function (done) {
+      appWithSocratesMember
+        .get('/edit')
+        .expect(200)
+        .expect(/Here you can edit your information\./, done);
+    });
+
+    it('allows a Softwerkskammer member to edit his page', function (done) {
+      appWithSoftwerkskammerMember
+        .get('/edit')
+        .expect(200)
+        .expect(/Here you find the information from your Softwerkskammer account that is used by SoCraTes\./, done);
+    });
+
+  });
+
+  describe('submitting a member page', function () {
 
   });
 

--- a/socrates/test/members/members_test.js
+++ b/socrates/test/members/members_test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var request = require('supertest');
+var sinon = require('sinon').sandbox.create();
+
+var beans = require('../../testutil/configureForTest').get('beans');
+var memberstore = beans.get('memberstore');
+var participantstore = beans.get('participantstore');
+var Member = beans.get('member');
+var Participant = beans.get('participant');
+
+var createApp = require('../../../softwerkskammer/testutil/testHelper')('socratesMembersApp').createApp;
+
+describe('SoCraTes members application', function () {
+  var appWithMember;
+
+  before(function () {
+    appWithMember = request(createApp('memberId'));
+  });
+
+  var member1;
+  var member2;
+  var participant1;
+  var participant2;
+
+  beforeEach(function () {
+    member1 = new Member({
+      id: 'memberId',
+      nickname: 'hada',
+      email: 'a@b.c',
+      site: 'http://my.blog',
+      firstname: 'Hans',
+      lastname: 'Dampf',
+      authentications: []
+    });
+    participant1 = new Participant({id: 'memberId'});
+
+    member2 = new Member({
+      id: 'memberId2',
+      nickname: 'nini',
+      email: 'x@y.com',
+      site: 'http://my.blog',
+      firstname: 'Petra',
+      lastname: 'Meier',
+      authentications: []
+    });
+    participant2 = new Participant({id: 'memberId2'});
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('accessing a member page', function () {
+
+    it('gives a 404 if there is no matching member in the database', function (done) {
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null); });
+
+      appWithMember
+        .get('/hada')
+        .expect(404, done);
+    });
+
+    it('gives a 404 if there is a member but no matching participant in the database', function (done) {
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member1); });
+      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null); });
+
+      appWithMember
+        .get('/hada')
+        .expect(404, done);
+    });
+
+    it('shows the participant\'s own page', function (done) {
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member1); });
+      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, participant1); });
+
+      appWithMember
+        .get('/hada')
+        .expect(200)
+        .expect(/First name:<\/strong> Hans/)
+        .expect(/Last name:<\/strong> Dampf/, done);
+    });
+
+    it('shows a different participant\'s page', function (done) {
+      sinon.stub(memberstore, 'getMember', function (nickname, callback) { callback(null, member2); });
+      sinon.stub(participantstore, 'getParticipant', function (nickname, callback) { callback(null, participant2); });
+
+      appWithMember
+        .get('/nini')
+        .expect(200)
+        .expect(/First name:<\/strong> Petra/)
+        .expect(/Last name:<\/strong> Meier/, done);
+    });
+
+  });
+
+});

--- a/socrates/test/members/members_test.js
+++ b/socrates/test/members/members_test.js
@@ -2,12 +2,15 @@
 
 var request = require('supertest');
 var sinon = require('sinon').sandbox.create();
+var expect = require('must');
 
 var beans = require('../../testutil/configureForTest').get('beans');
 var userWithoutMember = require('../../testutil/userWithoutMember');
-var accessrights = beans.get('accessrights');
+var membersService = beans.get('membersService');
 var memberstore = beans.get('memberstore');
 var participantstore = beans.get('participantstore');
+var notifications = beans.get('notifications');
+var groupsAndMembersService = beans.get('groupsAndMembersService');
 var Member = beans.get('member');
 var Participant = beans.get('participant');
 
@@ -51,7 +54,6 @@ describe('SoCraTes members application', function () {
     appWithSoftwerkskammerMember = request(createApp({member: softwerkskammerMember}));
     appWithSocratesMember = request(createApp({member: socratesMember}));
   });
-
 
   afterEach(function () {
     sinon.restore();
@@ -125,7 +127,163 @@ describe('SoCraTes members application', function () {
 
   });
 
-  describe('submitting a member page', function () {
+  describe('submitting a member form', function () {
+
+    it('rejects a member with invalid and different nickname on submit', function (done) {
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) {
+        callback(null, false);
+      });
+
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&firstname=A&lastname=B&email=c@d.de&previousEmail=c@d.de')
+        .send('nickname=nickerinack')
+        .send('previousNickname=bibabu')
+        .expect(200)
+        .expect(/Failed/)
+        .expect(/Validation/)
+        .expect(/This nickname is not available\./, done);
+    });
+
+    it('rejects a member with invalid and different email address on submit', function (done) {
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) {
+        callback(null, false);
+      });
+
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&firstname=Hans&lastname=Dampf&nickname=hada&previousNickname=hada')
+        .send('email=here@there.org')
+        .send('previousEmail=there@wherever.com')
+        .expect(200)
+        .expect(/Failed/)
+        .expect(/Validation/)
+        .expect(/This e-mail address is already registered\./, done);
+    });
+
+    it('rejects a member with missing first and last name on submit', function (done) {
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&&nickname=hada&previousNickname=hada&email=here@there.org&previousEmail=here@there.org')
+        .expect(200)
+        .expect(/Failed/)
+        .expect(/Validation/)
+        .expect(/First name is required\./)
+        .expect(/Last name is required\./, done);
+    });
+
+    it('rejects a member with missing first name who validly changed their nickname and mailaddress on submit', function (done) {
+      // attention: This combination is required to prove the invocations of the callbacks in case of no error!
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) {
+        callback(null, true);
+      });
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) {
+        callback(null, true);
+      });
+
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&&nickname=hadaNew&previousNickname=hada&lastname=x&email=hereNew@there.org&previousEmail=here@there.org')
+        .expect(200)
+        .expect(/Failed/)
+        .expect(/Validation/)
+        .expect(/First name is required\./, done);
+    });
+
+    it('rejects a member with invalid nickname and email address on submit, giving two error messages', function (done) {
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) {
+        callback(null, false);
+      });
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) {
+        callback(null, false);
+      });
+
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&firstname=A&lastname=B')
+        .send('nickname=nickerinack')
+        .send('previousNickname=hada')
+        .send('email=here@there.org')
+        .send('previousEmail=there@wherever.com')
+        .expect(200)
+        .expect(/Failed/)
+        .expect(/Validation/)
+        .expect(/This nickname is not available\./)
+        .expect(/This e-mail address is already registered\./, done);
+    });
+
+    it('saves an existing Softwerkskammer member, creates a participant because it is not yet there, and does not trigger notification sending', function (done) {
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
+      sinon.stub(memberstore, 'saveMember', function (member, callback) { callback(null); });
+      var participantSave = sinon.stub(participantstore, 'saveParticipant', function (participant, callback) { callback(null); });
+      var notificationCall = sinon.stub(notifications, 'newMemberRegistered', function () { return undefined; });
+
+      // the following stub indicates that the member already exists
+      sinon.stub(groupsAndMembersService, 'getUserWithHisGroups', function (nickname, callback) { callback(null, softwerkskammerMember); });
+      // and that the participant is not yet there
+      sinon.stub(participantstore, 'getParticipant', function (id, callback) { callback(null); });
+      appWithSoftwerkskammerMember
+        .post('/submit')
+        .send('id=0815&firstname=A&lastname=B')
+        .send('nickname=nickerinack')
+        .send('email=here@there.org')
+        .expect(302)
+        .expect('location', '/', function (err) {
+          expect(participantSave.called).to.be(true);
+          expect(notificationCall.called).to.be(false);
+          done(err);
+        });
+    });
+
+    it('saves an existing SoCraTes member, creates no participant because it is already there, and does not trigger notification sending', function (done) {
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
+      sinon.stub(memberstore, 'saveMember', function (member, callback) { callback(null); });
+      var participantSave = sinon.stub(participantstore, 'saveParticipant', function (participant, callback) { callback(null); });
+      var notificationCall = sinon.stub(notifications, 'newMemberRegistered', function () { return undefined; });
+
+      // the following stub indicates that the member already exists
+      sinon.stub(groupsAndMembersService, 'getUserWithHisGroups', function (nickname, callback) { callback(null, socratesMember); });
+      // and that the participant also exists
+      sinon.stub(participantstore, 'getParticipant', function (id, callback) { callback(null, socratesParticipant); });
+      appWithSocratesMember
+        .post('/submit')
+        .send('id=0815&firstname=A&lastname=B')
+        .send('nickname=nickerinack')
+        .send('email=here@there.org')
+        .expect(302)
+        .expect('location', '/', function (err) {
+          expect(participantSave.called).to.be(false);
+          expect(notificationCall.called).to.be(false);
+          done(err);
+        });
+    });
+
+    it('saves a new SoCraTes member and a new participant and triggers notification sending', function (done) {
+      sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
+      sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
+      sinon.stub(memberstore, 'allMembers', function (callback) { callback(null, [softwerkskammerMember, socratesMember]); });
+      sinon.stub(memberstore, 'saveMember', function (member, callback) { callback(null); });
+      var participantSave = sinon.stub(participantstore, 'saveParticipant', function (participant, callback) { callback(null); });
+      var notificationCall = sinon.stub(notifications, 'newMemberRegistered', function () { return undefined; });
+
+      // the following stub indicates that the member does not exist yet
+      sinon.stub(groupsAndMembersService, 'getUserWithHisGroups', function (nickname, callback) { callback(null); });
+      // and that the participant does not exist either
+      sinon.stub(participantstore, 'getParticipant', function (id, callback) { callback(null); });
+      appWithSocratesMember
+        .post('/submit')
+        .send('id=0815&firstname=A&lastname=B')
+        .send('nickname=nickerinack')
+        .send('email=here@there.org')
+        .expect(302)
+        .expect('location', '/', function (err) {
+          expect(participantSave.called).to.be(true);
+          expect(notificationCall.called).to.be(true);
+          done(err);
+        });
+    });
 
   });
 

--- a/socrates/test/participants/participantService_test.js
+++ b/socrates/test/participants/participantService_test.js
@@ -10,7 +10,7 @@ var memberstore = beans.get('memberstore');
 var participantstore = beans.get('participantstore');
 var Member = beans.get('member');
 
-describe('MembersService', function () {
+describe('ParticipantService', function () {
 
   var expectedMember = new Member({id: 'stubbed_member'});
   var participant = {id: 'stubbed_participant'};

--- a/socrates/testutil/testHelper.js
+++ b/socrates/testutil/testHelper.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var express = require('express');
+var userStub = require('../../softwerkskammer/testutil/userStub');
+var i18n = require('i18next');
+var jade = require('jade');
+
+module.exports = function (internalAppName, configuredBeans) {
+  var appName = internalAppName;
+  var beans = configuredBeans || require('./configureForTest').get('beans');
+
+  i18n.init({
+    supportedLngs: ['en'],
+    preload: ['en'],
+    fallbackLng: 'en',
+    resGetPath: 'locales/__ns__-__lng__.json'
+  });
+
+  return {
+    createApp: function (memberID) {  /* add middleware list as dynamic params */
+      var i;
+      var middleware;
+      var app = express();
+      app.locals.pretty = true;
+      app.enable('view cache');
+      app.use(require('cookie-parser')());
+      app.use(require('body-parser').urlencoded({extended: true}));
+      app.use(function (req, res, next) {
+        res.locals.removeServerpaths = function (msg) { return msg; };
+        next();
+      });
+      app.use(i18n.handle);
+      app.use(beans.get('expressSessionConfigurator'));
+
+      for (i = 1; i < arguments.length; i = i + 1) {
+        middleware = arguments[i];
+        if (middleware) {
+          app.use(middleware);
+        }
+      }
+
+      if (memberID) {
+        var Member = beans.get('member');
+        app.use(userStub({member: new Member({id: memberID})}));
+      }
+
+      app.use(beans.get('accessrights'));
+      app.use(beans.get('expressViewHelper'));
+      app.use('/', beans.get(appName));
+
+      var appLogger = { error: function () { return undefined; } };
+      app.use(beans.get('handle404')(appLogger));
+      app.use(beans.get('handle500')(appLogger));
+
+      i18n.registerAppHelper(app);
+      i18n.addPostProcessor('jade', function (val, key, opts) {
+        return jade.compile(val, opts)();
+      });
+      return app;
+    }
+  };
+};
+

--- a/socrates/testutil/userWithoutMember.js
+++ b/socrates/testutil/userWithoutMember.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function userWithoutMember(req, res, next) {
+  req.user = {};
+  next();
+};

--- a/socrates/views/layoutComponents.jade
+++ b/socrates/views/layoutComponents.jade
@@ -8,7 +8,7 @@ mixin loginMenu(forInline)
        |  #{t('general.guest')}
       ul.dropdown-menu
         if accessrights.isRegistered()
-          li: a(href='/registration/editmember')
+          li: a(href='/members/edit')
             span.glyphicon.glyphicon-edit
             | &nbsp;#{t('members.edit')}
           li: a(href='/auth/logout')

--- a/socrates/views/layoutComponents.jade
+++ b/socrates/views/layoutComponents.jade
@@ -67,9 +67,11 @@ mixin navbar(xs)
             span.glyphicon.glyphicon-book
             span.hidden-sm  #{t('wiki.wiki')}
           ul.dropdown-menu
-            if (wikisubdirs)
+            if (wikisubdirs && wikisubdirs.length)
               for subdir in wikisubdirs
                 li: a(href='/wiki/#{subdir}/') #{subdir}
+            else
+              li: a(href='/') <i>none</i>
         +loginMenu(true)
       
 mixin footer

--- a/softwerkskammer/test/members/members_test.js
+++ b/softwerkskammer/test/members/members_test.js
@@ -202,7 +202,7 @@ describe('Members application', function () {
       .expect(/Diese Adresse ist schon registriert\. Hast Du bereits ein Profil angelegt?/, done);
   });
 
-  it('saves an existing member and does not triggers notification sending', function (done) {
+  it('saves an existing member and does not trigger notification sending', function (done) {
     sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
     sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
     sinon.stub(groupsAndMembersService, 'updateSubscriptions', function (member, oldEmail, subscriptions, callback) { callback(); });
@@ -221,14 +221,14 @@ describe('Members application', function () {
       .expect('location', /members\/nickerinack/, done);
   });
 
-  it('saves a new member and does not triggers notification sending', function (done) {
+  it('saves a new member and does not trigger notification sending', function (done) {
     sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
     sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
     sinon.stub(groupsAndMembersService, 'updateSubscriptions', function (member, oldEmail, subscriptions, callback) { callback(); });
     sinon.stub(memberstore, 'saveMember', function (member, callback) { callback(null); });
     var notificationCall = sinon.spy(notifications, 'newMemberRegistered', function () { return undefined; });
 
-    // the following stub indicates that the member not yet exists 
+    // the following stub indicates that the member does not exist yet
     sinon.stub(groupsAndMembersService, 'getUserWithHisGroups', function (nickname, callback) { callback(null); });
     request(createApp('memberID'))
       .post('/submit')

--- a/softwerkskammer/test/members/members_test.js
+++ b/softwerkskammer/test/members/members_test.js
@@ -216,12 +216,14 @@ describe('Members application', function () {
       .send('id=0815&firstname=A&lastname=B&location=x&profession=y&reference=z')
       .send('nickname=nickerinack')
       .send('email=here@there.org')
-      .expect(function () { return notificationCall.called; }) // must return false to indicate correctness (thx supertest)
       .expect(302)
-      .expect('location', /members\/nickerinack/, done);
+      .expect('location', /members\/nickerinack/, function (err) {
+        expect(notificationCall.called).to.be(false);
+        done(err);
+      });
   });
 
-  it('saves a new member and does not trigger notification sending', function (done) {
+  it('saves a new member and triggers notification sending', function (done) {
     sinon.stub(membersService, 'isValidNickname', function (nickname, callback) { callback(null, true); });
     sinon.stub(membersService, 'isValidEmail', function (nickname, callback) { callback(null, true); });
     sinon.stub(groupsAndMembersService, 'updateSubscriptions', function (member, oldEmail, subscriptions, callback) { callback(); });
@@ -235,9 +237,11 @@ describe('Members application', function () {
       .send('id=0815&firstname=A&lastname=B&location=x&profession=y&reference=z')
       .send('nickname=nickerinack')
       .send('email=here@there.org')
-      .expect(function () { return !notificationCall.called; }) // must return false to indicate correctness (thx supertest)
       .expect(302)
-      .expect('location', /members\/nickerinack/, done);
+      .expect('location', /members\/nickerinack/, function (err) {
+        expect(notificationCall.called).to.be(true);
+        done(err);
+      });
   });
 
 });

--- a/softwerkskammer/test/middleware/secureSuperuserOnly_test.js
+++ b/softwerkskammer/test/middleware/secureSuperuserOnly_test.js
@@ -27,7 +27,7 @@ describe('redirectIfNotSuperuser', function () {
     });
   });
 
-  it('does not happpen when a normal user wants to access a page with "administatrion" as part of the URL', function (done) {
+  it('does not happpen when a normal user wants to access a page with "administration" as part of the URL', function (done) {
     var originalUrl = '/member/administration/';
 
     var req = { originalUrl: originalUrl };


### PR DESCRIPTION
API cleanup: Moved /registration/editmember and /registration/submitmember to /members/edit and /members/submit
Added tests for members API.
Bugfix: Wiki menu didn't work when there were no wikis.