### PR TITLE
Fix for "Monatsübergreifende Activities werden im Kalender falsch dargestellt #904"

### DIFF
--- a/softwerkskammer/lib/activities/activitystore.js
+++ b/softwerkskammer/lib/activities/activitystore.js
@@ -32,7 +32,7 @@ function allActivitiesByDateRange(rangeFrom, rangeTo, sortOrder, callback) {
   persistence.listByField({
     $and: [
       {endUnix: {$gt: rangeFrom}},
-      {endUnix: {$lt: rangeTo}}
+      {startUnix: {$lt: rangeTo}}
     ]
   }, sortOrder, _.partial(toActivityList, callback));
 }

--- a/softwerkskammer/testWithDB/activitiesDB/activities_index_upcoming_past_test.js
+++ b/softwerkskammer/testWithDB/activitiesDB/activities_index_upcoming_past_test.js
@@ -20,15 +20,48 @@ describe('Activity application with DB - shows activities -', function () {
   var yesterday = moment().subtract(1, 'days');
   var dayBeforeYesterday = moment().subtract(2, 'days');
 
-  var futureActivity = new Activity({id: 'futureActivity', title: 'Future Activity', description: 'description1', assignedGroup: 'groupname',
-    location: 'location1', direction: 'direction1', startUnix: tomorrow.unix(), endUnix: dayAfterTomorrow.unix(),
-    url: 'url_future', owner: 'owner', resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true }}, version: 1});
-  var currentActivity = new Activity({id: 'currentActivity', title: 'Current Activity', description: 'description1', assignedGroup: 'groupname',
-    location: 'location1', direction: 'direction1', startUnix: yesterday.unix(), endUnix: tomorrow.unix(),
-    url: 'url_current', owner: 'owner', resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true }}, version: 1});
-  var pastActivity = new Activity({id: 'pastActivity', title: 'Past Activity', description: 'description1', assignedGroup: 'groupname',
-    location: 'location1', direction: 'direction1', startUnix: dayBeforeYesterday.unix(), endUnix: yesterday.unix(),
-    url: 'url_past', owner: 'owner', resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true }}, version: 1});
+  var futureActivity = new Activity({
+    id: 'futureActivity',
+    title: 'Future Activity',
+    description: 'description1',
+    assignedGroup: 'groupname',
+    location: 'location1',
+    direction: 'direction1',
+    startUnix: tomorrow.unix(),
+    endUnix: dayAfterTomorrow.unix(),
+    url: 'url_future',
+    owner: 'owner',
+    resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true}},
+    version: 1
+  });
+  var currentActivity = new Activity({
+    id: 'currentActivity',
+    title: 'Current Activity',
+    description: 'description1',
+    assignedGroup: 'groupname',
+    location: 'location1',
+    direction: 'direction1',
+    startUnix: yesterday.unix(),
+    endUnix: tomorrow.unix(),
+    url: 'url_current',
+    owner: 'owner',
+    resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true}},
+    version: 1
+  });
+  var pastActivity = new Activity({
+    id: 'pastActivity',
+    title: 'Past Activity',
+    description: 'description1',
+    assignedGroup: 'groupname',
+    location: 'location1',
+    direction: 'direction1',
+    startUnix: dayBeforeYesterday.unix(),
+    endUnix: yesterday.unix(),
+    url: 'url_past',
+    owner: 'owner',
+    resources: {Veranstaltung: {_registeredMembers: [], _registrationOpen: true}},
+    version: 1
+  });
 
   beforeEach(function (done) { // if this fails, you need to start your mongo DB
 
@@ -61,13 +94,13 @@ describe('Activity application with DB - shows activities -', function () {
       });
   });
 
-  it('shows only past activities as past', function (done) {
+  it('shows only current and past activities as past', function (done) {
 
     request(createApp())
       .get('/past')
       .expect(200)
+      .expect(/Current Activity/)
       .expect(/Past Activity/, function (err, res) {
-        expect(res.text).to.not.contain('Current Activity');
         expect(res.text).to.not.contain('Future Activity');
         done(err);
       });


### PR DESCRIPTION
- tradeoff: vergangene Events enthalten jetzt auch aktuell laufende