### PR TITLE
Update documentation and minimal engine version: Agora needs at least Node 6.x

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 It is a node.js project. Therefore you need node.js installed. Get it from [http://nodejs.org](http://nodejs.org).
 
-You need a current 6.x version to run the software (4.x should also be OK).
+You need a current 6.x version to run the software.
 
 Your node.js ships npm in a suitable version.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "dependencies": {
     "CoolBeans": "0.0.9",


### PR DESCRIPTION
As newer ECMAScript features are used Agora doesn't build and run on
Node 4.x anymore: you get errors like "block-scoped declarations not yet
supported outside strict mode".