### PR TITLE
Rearrange dashboard content

### DIFF
--- a/locales/translation-de.json
+++ b/locales/translation-de.json
@@ -130,8 +130,10 @@
   "dashboard": {
     "dashboard": "Überblick",
     "description": [
-      "p Deine persönliche Softwerkskammer. Wir zeigen Dir hier Deine Gruppen und ihre Aktivitäten."
-    ]
+      "Deine persönliche Softwerkskammer"
+    ],
+    "upcoming_activities": "$t(activities.upcoming_activities) Deiner Gruppen",
+    "your_groups": "Deine Gruppen"
   },
   "error": {
     "click_links": "Am Besten klickst Du auf einen unserer Links im Header.",

--- a/locales/translation-en.json
+++ b/locales/translation-en.json
@@ -138,8 +138,10 @@
   "dashboard": {
     "dashboard": "Dashboard",
     "description": [
-      "p Your personal view to softwerkskammer. It shows your groups and their upcoming activities."
-    ]
+      "Your personal view to softwerkskammer"
+    ],
+    "upcoming_activities": "$t(activities.upcoming_activities) of your groups",
+    "your_groups": "Your groups"
   },
   "error": {
     "click_links": "I'd suggest you click on one of the links in the header.",

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -14,13 +14,14 @@ block content
   .page-header
     h2 #{t('dashboard.dashboard')}
       small
-        !=t('dashboard.description', { postProcess: 'pug' })
+        p #{t('dashboard.description')}
   .row
     .col-sm-6
       +my_activities
   +my_groups
 
 mixin my_groups
+  h3 #{t('dashboard.your_groups')}
   .row
     each groups in groupsPerColumn
       .col-sm-4
@@ -46,7 +47,7 @@ mixin my_groups
 mixin my_activities
   .panel.panel-default
     .panel-heading
-      b #{t('activities.upcoming_activities')}
+      b #{t('dashboard.upcoming_activities')}
     ul.list-group
       each activity in activities
         -var angemeldet = (member && activity.allRegisteredMembers().indexOf(member.id()) > -1)

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -11,6 +11,8 @@ block scripts
 block title
   | Dashboard
 block content
+  h1 #{t('dashboard.dashboard')}
+  !=t('dashboard.description', { postProcess: 'pug' })
   .row
     .col-sm-6
       +my_activities

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -16,12 +16,6 @@ block content
   .row
     .col-sm-6
       +my_activities
-    .col-sm-6
-      .panel.panel-default
-        .panel-heading
-          b #{t('dashboard.dashboard')}
-        .panel-body
-          !=t('dashboard.description', { postProcess: 'pug' })
   +my_groups
 
 mixin my_groups

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -13,11 +13,12 @@ block title
 block content
   .page-header
     h2 #{t('dashboard.dashboard')}
-    !=t('dashboard.description', { postProcess: 'pug' })
-    .row
-      .col-sm-6
-        +my_activities
-    +my_groups
+      small
+        !=t('dashboard.description', { postProcess: 'pug' })
+  .row
+    .col-sm-6
+      +my_activities
+  +my_groups
 
 mixin my_groups
   .row

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -70,7 +70,7 @@ mixin wikichangesOrBlogs(items, panelid, prefix, title)
     div(class=prefix + ' collapse in')
       ul.list-unstyled
         each item in items
-          li.dashboard-line
+          li
             .modal.fade.bs-modal-lg(id=item.dialogId(), tabindex='-1')
               .modal-dialog.modal-lg
                 .modal-content

--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -11,12 +11,13 @@ block scripts
 block title
   | Dashboard
 block content
-  h1 #{t('dashboard.dashboard')}
-  !=t('dashboard.description', { postProcess: 'pug' })
-  .row
-    .col-sm-6
-      +my_activities
-  +my_groups
+  .page-header
+    h2 #{t('dashboard.dashboard')}
+    !=t('dashboard.description', { postProcess: 'pug' })
+    .row
+      .col-sm-6
+        +my_activities
+    +my_groups
 
 mixin my_groups
   .row

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -12,11 +12,12 @@ block title
 block content
   .page-header
     h2 #{t('dashboard.dashboard')}
-    !=t('dashboard.description', { postProcess: 'pug' })
-    .row
-      .col-sm-6
-        +my_activities
-    +my_groups
+      small
+        !=t('dashboard.description', { postProcess: 'pug' })
+  .row
+    .col-sm-6
+      +my_activities
+  +my_groups
 
 mixin mailIndex(mailHeaders)
   if (mailHeaders)

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -10,12 +10,13 @@ block scripts
 block title
   | Dashboard
 block content
-  h1 #{t('dashboard.dashboard')}
-  !=t('dashboard.description', { postProcess: 'pug' })
-  .row
-    .col-sm-6
-      +my_activities
-  +my_groups
+  .page-header
+    h2 #{t('dashboard.dashboard')}
+    !=t('dashboard.description', { postProcess: 'pug' })
+    .row
+      .col-sm-6
+        +my_activities
+    +my_groups
 
 mixin mailIndex(mailHeaders)
   if (mailHeaders)

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -10,6 +10,8 @@ block scripts
 block title
   | Dashboard
 block content
+  h1 #{t('dashboard.dashboard')}
+  !=t('dashboard.description', { postProcess: 'pug' })
   .row
     .col-sm-6
       +my_activities

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -13,7 +13,7 @@ block content
   .page-header
     h2 #{t('dashboard.dashboard')}
       small
-        !=t('dashboard.description', { postProcess: 'pug' })
+        p #{t('dashboard.description')}
   .row
     .col-sm-6
       +my_activities
@@ -42,6 +42,7 @@ mixin mailattributes(mailHeader)
   .clearfix
 
 mixin my_groups
+  h3 #{t('dashboard.your_groups')}
   .row
     each groups in groupsPerColumn
       .col-sm-4
@@ -67,7 +68,7 @@ mixin my_groups
 mixin my_activities
   .panel.panel-default
     .panel-heading
-      b #{t('activities.upcoming_activities')}
+      b #{t('dashboard.upcoming_activities')}
     ul.list-group
       each activity in activities
         -var angemeldet = (memberId && activity.allRegisteredMembers.indexOf(memberId) > -1)

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -44,26 +44,27 @@ mixin mailattributes(mailHeader)
   .clearfix
 
 mixin my_groups
-  each groups in groupsPerColumn
-    .col-sm-4
-      each group in groups
-        -var panelid = group.id + '-grouppanel'
-        .panel.panel-default
-          .panel-heading(style='background-color: ' + group.color + '; color: #FFFFFF;')
-            a.inherit-color.chevron(data-toggle='collapse', data-target='#' + panelid): b
-              i.fa.fa-toggle-down.fa-fw.blog
-            | &nbsp;#{group.longName}
-            a.inherit-color(href='/groups/' + group.id): span.pull-right: i.fa.fa-group.fa-fw.tooltipify(data-toggle='tooltip', title=t('groups.tooltip.gotogroup'))
-          .panel-body.collapse.in(id=panelid)
-            +wikichangesOrBlogs(postsByGroup[group.id], panelid, 'blogs', t('wiki.blogposts'))
-            +wikichangesOrBlogs(changesByGroup[group.id], panelid, 'changes', t('wiki.changes'))
-            if (mailsByGroup[group.id].length > 0)
-            h5
-            a.chevron(data-toggle='collapse', data-target='#' + panelid + ' .mails')
-              i.fa.fa-toggle-down.fa-fw.blog
-              | &nbsp;#{t('mailarchive.recent')}
-              .mails.collapse.in
-                +mailIndex(mailsByGroup[group.id])
+  .row
+    each groups in groupsPerColumn
+      .col-sm-4
+        each group in groups
+          -var panelid = group.id + '-grouppanel'
+          .panel.panel-default
+            .panel-heading(style='background-color: ' + group.color + '; color: #FFFFFF;')
+              a.inherit-color.chevron(data-toggle='collapse', data-target='#' + panelid): b
+                i.fa.fa-toggle-down.fa-fw.blog
+              | &nbsp;#{group.longName}
+              a.inherit-color(href='/groups/' + group.id): span.pull-right: i.fa.fa-group.fa-fw.tooltipify(data-toggle='tooltip', title=t('groups.tooltip.gotogroup'))
+            .panel-body.collapse.in(id=panelid)
+              +wikichangesOrBlogs(postsByGroup[group.id], panelid, 'blogs', t('wiki.blogposts'))
+              +wikichangesOrBlogs(changesByGroup[group.id], panelid, 'changes', t('wiki.changes'))
+              if (mailsByGroup[group.id].length > 0)
+              h5
+              a.chevron(data-toggle='collapse', data-target='#' + panelid + ' .mails')
+                i.fa.fa-toggle-down.fa-fw.blog
+                | &nbsp;#{t('mailarchive.recent')}
+                .mails.collapse.in
+                  +mailIndex(mailsByGroup[group.id])
 
 mixin my_activities
   .panel.panel-default

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -15,12 +15,6 @@ block content
   .row
     .col-sm-6
       +my_activities
-    .col-sm-6
-      .panel.panel-default
-        .panel-heading
-          b #{t('dashboard.dashboard')}
-        .panel-body
-          !=t('dashboard.description', { postProcess: 'pug' })
   +my_groups
 
 mixin mailIndex(mailHeaders)


### PR DESCRIPTION
Now the description (what the dashboard is for and what is displayed) is moved above the actual content and is not placed in a panel any more. This seems more logical to me.

I also found some inconsistencies between the legacy and non-legacy version of the Pug templates and fixed them in separate commits. I'm not complete sure whether now the are equivalent because I didn't completely understand why they differ for some dynamic content.