### PR TITLE
issue 1146 - added bootstraps clearfix style class for the list-group…

### DIFF
--- a/softwerkskammer/lib/dashboard/views/index.pug
+++ b/softwerkskammer/lib/dashboard/views/index.pug
@@ -52,7 +52,7 @@ mixin my_activities
     ul.list-group
       each activity in activities
         -var angemeldet = (member && activity.allRegisteredMembers().indexOf(member.id()) > -1)
-        li.list-group-item
+        li.list-group-item.clearfix
           if (angemeldet)
             i.fa.fa-check.fa-fw.text-success.tooltipify(data-toggle='tooltip', title=t('activities.tooltip.registered'))
           else

--- a/softwerkskammer/lib/dashboard/views/indexJson.pug
+++ b/softwerkskammer/lib/dashboard/views/indexJson.pug
@@ -72,7 +72,7 @@ mixin my_activities
     ul.list-group
       each activity in activities
         -var angemeldet = (memberId && activity.allRegisteredMembers.indexOf(memberId) > -1)
-        li.list-group-item
+        li.list-group-item.clearfix
           if (angemeldet)
             i.fa.fa-check.fa-fw.text-success.tooltipify(data-toggle='tooltip', title=t('activities.tooltip.registered'))
           else


### PR DESCRIPTION
Fix tested with Mac/Firefox 48.0.1 and Android 5.1.0/Chrome 52

<img width="1518" alt="bildschirmfoto 2016-09-23 um 21 31 09" src="https://cloud.githubusercontent.com/assets/3167633/18799078/13675fae-81d6-11e6-906d-8694a1c77575.png">
…-item in the dashboard page to avoid the group labels to get out of the surrounding cell