### PR TITLE
Editing profile may kill interests if string is separated by ', ' (comma blank)

### DIFF
--- a/softwerkskammer/lib/members/member.js
+++ b/softwerkskammer/lib/members/member.js
@@ -148,7 +148,7 @@ Member.prototype.interests = function () {
 };
 
 Member.prototype.interestsForSelect2 = function () {
-  return _(this.interests()).words(/[^,]+/g);
+  return _(this.interests()).words(/[^,]+/g).map(s => s.trim()).value();
 };
 
 Member.prototype.reference = function () {

--- a/softwerkskammer/test/members/member_object_test.js
+++ b/softwerkskammer/test/members/member_object_test.js
@@ -285,3 +285,18 @@ describe('avatar handling', function () {
     expect(member.hasImage()).to.be(true);
   });
 });
+
+describe('The interests', function () {
+
+  it('creates an array for the select2 widget (good case)', function () {
+    var member = new Member();
+    member.state.interests = 'peter,paul und mary';
+    expect(member.interestsForSelect2()).to.eql(['peter', 'paul und mary']);
+  });
+
+  it('creates an array for the select2 widget (with blanks)', function () {
+    var member = new Member();
+    member.state.interests = 'peter , paul und mary';
+    expect(member.interestsForSelect2()).to.eql(['peter', 'paul und mary']);
+  });
+});


### PR DESCRIPTION
fix for #1163 