### PR TITLE
Bumped current year to 2017 ...

### DIFF
--- a/socrates/lib/activities/socratesConstants.js
+++ b/socrates/lib/activities/socratesConstants.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var currentYear = 2016;
+var currentYear = 2017;
 
 module.exports.currentYear = currentYear;
 module.exports.urlPrefix = 'socrates-';


### PR DESCRIPTION
to avoid the awkwardness of displaying "SoCraTes 2017" (from Pascal's change) together with "Can't make it to SoCraTes? Tell us!" (because the code still refers to 2016).
