### PR TITLE
Wiki 

### DIFF
--- a/socrates/lib/wiki/views/participants.pug
+++ b/socrates/lib/wiki/views/participants.pug
@@ -1,24 +1,26 @@
 extends ../../../views/layoutNoFooter
 include  ../../../../commonComponents/pug/formComponents
 include ../../../../softwerkskammer/lib/members/views/editavatar
+include ../../../../softwerkskammer/lib/members/views/memberlist-mixin
+
 
 block title
   | Participants
 block content
   .row
     .col-md-12
-      each participant in participants
-        div(id=participant.nickname())
-          if accessrights.canEditMember(participant)
-            h4
-              .btn-group
-                a.btn.btn-primary(href='/members/editForParticipantListing', title=t('general.edit'))
-                  i.fa.fa-edit.fa-fw
-                  |  #{participant.displayName()}
-          else
-            h4: a(href='/members/' + participant.nickname()) #{participant.displayName()}
-          .row
-            if showQuestions
+      if showQuestions
+        each participant in participants
+          div(id=participant.nickname())
+            if accessrights.canEditMember(participant)
+              h4
+                .btn-group
+                  a.btn.btn-primary(href='/members/editForParticipantListing', title=t('general.edit'))
+                    i.fa.fa-edit.fa-fw
+                    |  #{participant.displayName()}
+            else
+              h4: a(href='/members/' + participant.nickname()) #{participant.displayName()}
+            .row
               .col-sm-3.col-sm-push-9
                 +avatar(participant, true)
               .col-sm-9.col-sm-pull-3
@@ -28,10 +30,10 @@ block content
                 | !{participant.participation.question2Html()}
                 h5: em What do you want to take home from the event?
                 | !{participant.participation.question3Html()}
-            else
-              +avatar(participant, true)
+            hr
+      else
+        +memberlist(participants)
 
-          hr
 
 block scripts
   +avatarscript

--- a/socrates/test/wiki/wiki_test.js
+++ b/socrates/test/wiki/wiki_test.js
@@ -40,15 +40,16 @@ describe('SoCraTes wiki application', () => {
     it('and shows no editing option for anybody and does not show the questions in 2016', done => {
       request(createApp({id: 'anybody'}))
         .get('/2016/participantsOverview')
-        .expect(/<h4><a href="\/members\/nick">first last/)
+        .expect(/<a href="\/members\/nick">nick/)
+        .expect(/first last/)
         .expect(200, (err, res) => {
           expect(res.text).to.not.contain('What is your relation to Software Craftsmanship?');
           done(err);
         });
     });
-    it('and shows an editing option for the current user', done => {
+    it('and shows an editing option for the current user in 2015', done => {
       request(createApp({id: 'userid'}))
-        .get('/2016/participantsOverview')
+        .get('/2015/participantsOverview')
         .expect(/<h4><div class="btn-group"><a class="btn btn-primary" href="\/members\/editForParticipantListing" title="Edit"><i class="fa fa-edit fa-fw"><\/i> first last/)
         .expect(200, done);
     });


### PR DESCRIPTION
Um die Darstellungsgröße der Teilnehmerliste im Wiki etwas zu reduzieren, wird jetzt dieselbe Listendarstellung verwendet wie auf der Mitgliederseite der Softwerkskammer.
