### PR TITLE
Add step for minimal mailsender configuration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,6 +71,7 @@ To set up the built-in wiki follow [these instructions for Softwerkskammer](soft
 Configuration for Softwerkskammer and SoCraTes:
 
 * Copy the logging configuration file `config/example-winston-config.json` to `config/winston-config.json`, remove the comment in the first line, and adapt the paths if you like.
+* Copy the mailsender configuration file `config/example(smtp)-mailsender-config.json` to `config/mailsender-config.json`, remove the comment in the first line. Without setting up a proper server sending mails won't work but this configuration is sufficient to be able to start both the softwerkskammer and socrates app.
 
 ### Running the server
 


### PR DESCRIPTION
Without this setup starting both the softwerkskammer and the socrates app failed because the transporter configuration object passed to nodemailer was undefined:

```
> Agora@1.0.0 start /home/urs/programming/Agora
> node start-softwerkskammer

/home/urs/programming/Agora/node_modules/nodemailer/lib/mailer/index.js:45
        this.transporter.mailer = this;
                                ^

TypeError: Cannot set property 'mailer' of undefined
    at Mail (/home/urs/programming/Agora/node_modules/nodemailer/lib/mailer/index.js:45:33)
    at Object.module.exports.createTransport (/home/urs/programming/Agora/node_modules/nodemailer/lib/nodemailer.js:41:14)
    at Object.<anonymous> (/home/urs/programming/Agora/softwerkskammer/lib/mailsender/nodemailerTransport.js:3:40)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at get (/home/urs/programming/Agora/node_modules/CoolBeans/lib/CoolBeans.js:36:11)
    at Object.<anonymous> (/home/urs/programming/Agora/softwerkskammer/lib/mailsender/mailtransport.js:12:25)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
```