### PR TITLE
Socrates configurable twitter info

### DIFF
--- a/Gruntfile-SoCraTes.js
+++ b/Gruntfile-SoCraTes.js
@@ -219,7 +219,6 @@ module.exports = function (grunt) {
       standard: {
         options: {
           disallowAttributeInterpolation: true,
-          disallowAttributeTemplateString: true,
           disallowDuplicateAttributes: true,
           disallowIdAttributeWithStaticValue: true,
           disallowLegacyMixinCall: true,

--- a/socrates/lib/activities/socratesConstants.js
+++ b/socrates/lib/activities/socratesConstants.js
@@ -7,3 +7,9 @@ module.exports.urlPrefix = 'socrates-';
 module.exports.currentUrl = this.urlPrefix + currentYear;
 
 module.exports.registrationPeriodinMinutes = 30;
+
+module.exports.twitterConstants = {
+  twitterHandle: 'SoCraTes_Conf',
+  urlEncodedTweetText: `SoCraTes+${currentYear}+will+take+place+from+24+to+27+August.+More+at&url=http%3A%2F%2Fsocrates-conference.de%2F`,
+  hashtag: 'socrates_17'
+};

--- a/socrates/lib/middleware/expressViewHelper.js
+++ b/socrates/lib/middleware/expressViewHelper.js
@@ -3,6 +3,7 @@
 const conf = require('simple-configure');
 const beans = conf.get('beans');
 const statusmessage = beans.get('statusmessage');
+const socratesConstants = beans.get('socratesConstants');
 
 module.exports = function expressViewHelper(req, res, next) {
   if (req.session) {
@@ -14,5 +15,6 @@ module.exports = function expressViewHelper(req, res, next) {
   res.locals.user = req.user;
   res.locals.currentUrl = req.url;
   res.locals.swkPublicUrl = conf.get('softwerkskammerURL');
+  res.locals.twitterConstants = socratesConstants.twitterConstants;
   next();
 };

--- a/socrates/views/layoutComponents.pug
+++ b/socrates/views/layoutComponents.pug
@@ -87,7 +87,10 @@ mixin footer
                   +contactbuttons
 
 mixin contactbuttons
-  -const socratesTwitterHandle = "SoCraTes_Conf";
+  -const socratesTwitterHandle = 'SoCraTes_Conf';
+  -const year = 2017;
+  -const urlEncodedTweetText = `SoCraTes+${year}+will+take+place+from+24+to+27+August.+More+at&url=http%3A%2F%2Fsocrates-conference.de%2F`;
+  -const socratesHashtag = 'socrates_17';
 
   a.btn.btn-info(href='/registration/ical', title=t('activities.export'))
     span.glyphicon.glyphicon-download-alt
@@ -99,11 +102,11 @@ mixin contactbuttons
     i.fa.fa-fw.fa-envelope
     span.hidden-xs #{' ' + t('members.email')}
   .btn-group.dropup
-    a.btn.btn-info(href='https://twitter.com/intent/tweet?text=SoCraTes+2017+will+take+place+from+24+to+27+August.+More+at&url=http%3A%2F%2Fsocrates-conference.de%2F&hashtags=socrates_17&via=' + socratesTwitterHandle, title='Tweet')
+    a.btn.btn-info(href=`https://twitter.com/intent/tweet?text=${urlEncodedTweetText}&hashtags=${socratesHashtag}&via=${socratesTwitterHandle}`, title='Tweet')
       i.fa.fa-fw.fa-twitter
       span.hidden-xs #{' ' + t('general.tweet')}
     a.btn.btn-info.dropdown-toggle(data-toggle='dropdown')
       i.fa.fa-caret-up
     ul.dropdown-menu(role='menu')
-      li: a(href='https://twitter.com/intent/user?screen_name=' + socratesTwitterHandle) #{t('general.show_tweets')}
-      li: a(href='https://twitter.com/intent/follow?screen_name=' + socratesTwitterHandle) #{t('general.follow')}
+      li: a(href=`https://twitter.com/intent/user?screen_name=${socratesTwitterHandle}`) #{t('general.show_tweets')}
+      li: a(href=`https://twitter.com/intent/follow?screen_name=${socratesTwitterHandle}`) #{t('general.follow')}

--- a/socrates/views/layoutComponents.pug
+++ b/socrates/views/layoutComponents.pug
@@ -87,11 +87,6 @@ mixin footer
                   +contactbuttons
 
 mixin contactbuttons
-  -const socratesTwitterHandle = 'SoCraTes_Conf';
-  -const year = 2017;
-  -const urlEncodedTweetText = `SoCraTes+${year}+will+take+place+from+24+to+27+August.+More+at&url=http%3A%2F%2Fsocrates-conference.de%2F`;
-  -const socratesHashtag = 'socrates_17';
-
   a.btn.btn-info(href='/registration/ical', title=t('activities.export'))
     span.glyphicon.glyphicon-download-alt
     span.hidden-xs #{' ' + t('activities.ical')}
@@ -102,11 +97,11 @@ mixin contactbuttons
     i.fa.fa-fw.fa-envelope
     span.hidden-xs #{' ' + t('members.email')}
   .btn-group.dropup
-    a.btn.btn-info(href=`https://twitter.com/intent/tweet?text=${urlEncodedTweetText}&hashtags=${socratesHashtag}&via=${socratesTwitterHandle}`, title='Tweet')
+    a.btn.btn-info(href=`https://twitter.com/intent/tweet?text=${twitterConstants.urlEncodedTweetText}&hashtags=${twitterConstants.hashtag}&via=${twitterConstants.twitterHandle}`, title='Tweet')
       i.fa.fa-fw.fa-twitter
       span.hidden-xs #{' ' + t('general.tweet')}
     a.btn.btn-info.dropdown-toggle(data-toggle='dropdown')
       i.fa.fa-caret-up
     ul.dropdown-menu(role='menu')
-      li: a(href=`https://twitter.com/intent/user?screen_name=${socratesTwitterHandle}`) #{t('general.show_tweets')}
-      li: a(href=`https://twitter.com/intent/follow?screen_name=${socratesTwitterHandle}`) #{t('general.follow')}
+      li: a(href=`https://twitter.com/intent/user?screen_name=${twitterConstants.twitterHandle}`) #{t('general.show_tweets')}
+      li: a(href=`https://twitter.com/intent/follow?screen_name=${twitterConstants.twitterHandle}`) #{t('general.follow')}


### PR DESCRIPTION
Follow-up to #1245:
* Extract volatile twitter data into the exisiting `socratesConstants.js` file. First I had a separate `socratesTwitterConstants.js` file but as I wanted to reuse the constant `currentYear` and the data seemed cohesive enough I put it into the existing file, is this okay with you or should I change that?
* I added a "global import" of the constants into `expressViewHelpers.js` so that it is not necessary to pass them to every render call. I hope that was the right approach.
* I only adjusted the puglint settings in `Gruntfile-SoCraTes.js` but that was enough to make linting happy, should the softwerkskammer Gruntfile also be adjusted (or could the linting settings be merged?).