### PR TITLE
change innoq email as per E-Mail requested.

### DIFF
--- a/socrates/lib/site/sponsors.json
+++ b/socrates/lib/site/sponsors.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "innoQ",
-    "url": "http://www.innoq.de",
+    "url": "https://www.innoq.com/",
     "logo": "innoq160.png"
   },
   {


### PR DESCRIPTION
Got this E-Mail:

Hello, Alexandre,
a remark from the side line:
Regarding our sponsor link: The http://www.innoq.de/ you gave in the email works, but the canonical innoQ-URI is https://www.innoq.com/ .
The one you gave redirects to the canonical one. So there is no real harm done, no need for corrective follow-up mails or any big hassle.
But there will be further announcements of sponsors, I presume. And if those future announcements have the canonical innoQ-URI, I'd think that'd be nice.
Have a nice day!
Andreas
-- 
Dr. Andreas Krüger, andreas.krueger@innoq.com, https://www.innoq.com
innoQ Deutschland GmbH, Ohlauer Straße 43, 10999 Berlin, Germany
Mobile: +49 151 46 136 423
You may write to me in English. Man kann mir auf deutsch schreiben.
