### PR TITLE
Add (blank) pronoun and languages to nametags

### DIFF
--- a/socrates/lib/registration/nametagService.js
+++ b/socrates/lib/registration/nametagService.js
@@ -49,11 +49,13 @@ module.exports = {
       '\n' +
       '\\newcommand{\\nametag}[3]{%\n' +
       '  \\parbox[t]{' + tags.colWidth + '}{\\rule[0mm]{0mm}{' + tags.tagHeight + '}%\n' +
-      '    \\hspace{10mm}' +
+      '    \\hspace{5mm}' +
       '    \\begin{minipage}[b]{' + tags.colWidth + '}%\n' +
-      '      {\\Huge \\textbf{#1}}\\\\[5mm]%\n' +
-      '      {\\large #2}\\\\[5mm]%\n' +
-      '    {\\Large \\textbf{\\texttt{#3}}}\\\\[' + tags.bottomMargin + ']%\n' +
+
+      '      \\\\{\\Huge \\textbf{#1}}\\\\[3mm]%\n' +
+      '      {\\large #2}\\\\[3mm]%\n' +
+          ' {\\Large \\texttt{#3}}\\\\    {\\Small        \\texttt{Pronoun:}\\\\        \\qquad\\texttt{Languages: }    }\\\\' +
+      '[' + tags.bottomMargin + ']%\n' +
       ' \\end{minipage}}}%\n' +
       '\n' +
       '\n' +


### PR DESCRIPTION
We decided to not fill in the values from the member database because we don't
have info on languages and the pronoun data is rather incomplete and full of
names instead of pronouns. Let people be creative :)

<3 from Nuremberg, Alex and Chris