### PR TITLE
Display recent activities in a group

### DIFF
--- a/locales/translation-de.json
+++ b/locales/translation-de.json
@@ -42,6 +42,8 @@
     "past": "Vergangene",
     "possible": "möglich",
     "previous_gdcr": "Vergangene GDCRs",
+    "recent": "Letzte",
+    "recent_activities": "$t(activities.recent) $t(activities.activities)",
     "register_until": "Kann sich registrieren bis",
     "registration": "Anmeldung",
     "registration_not_here": "Anmeldung ist nicht über die Softwerkskammer möglich.",

--- a/locales/translation-en.json
+++ b/locales/translation-en.json
@@ -45,6 +45,8 @@
     "past": "Past",
     "possible": "possible",
     "previous_gdcr": "Previous GDCRs",
+    "recent": "Recent",
+    "recent_activities": "$t(activities.recent) $t(activities.activities)",
     "register_until": "Can register until",
     "registration": "Subscription",
     "registration_is_full": "Subscription for the selected room type is no longer possible because all spots are taken. Please try again with a different room type.",

--- a/softwerkskammer/lib/activities/activitystore.js
+++ b/softwerkskammer/lib/activities/activitystore.js
@@ -96,6 +96,17 @@ module.exports = {
     }, {startUnix: 1}, R.partial(toActivityList, [callback]));
   },
 
+  pastActivitiesForGroupIds: function pastActivitiesForGroupIds(groupIds, callback) {
+    const start = moment().unix();
+
+    persistence.listByField({
+      $and: [
+        {endUnix: {$lt: start}},
+        {assignedGroup: {$in: groupIds}}
+      ]
+    }, {startUnix: -1}, R.partial(toActivityList, [callback]));
+  },
+
   activitiesForGroupIdsAndRegisteredMemberId: function activitiesForGroupIdsAndRegisteredMemberId(groupIds, memberId, upcoming, callback) {
     function map() {
       /* eslint no-underscore-dangle: 0 */

--- a/softwerkskammer/lib/activities/index.js
+++ b/softwerkskammer/lib/activities/index.js
@@ -210,9 +210,7 @@ app.post('/submit', (req, res, next) => {
   async.parallel(
     [
       callback => {
-        // we need this helper function (in order to have a closure?!)
-        const validityChecker = (url, cb) => { activitiesService.isValidUrl(reservedURLs, url, cb); };
-        validation.checkValidity(req.body.previousUrl.trim(), req.body.url.trim(), validityChecker, req.i18n.t('validation.url_not_available'), callback);
+        validation.checkValidity(req.body.previousUrl.trim(), req.body.url.trim(), R.partial(activitiesService.isValidUrl, [reservedURLs]), req.i18n.t('validation.url_not_available'), callback);
       },
       callback => {
         const errors = validation.isValidForActivity(req.body);

--- a/softwerkskammer/lib/activities/index.js
+++ b/softwerkskammer/lib/activities/index.js
@@ -301,11 +301,11 @@ function addToWaitinglist(body, req, res, next) {
 }
 
 app.post('/addToWaitinglist', (req, res, next) => {
-  // in case the call was redirected via login, we get called with "get"
   addToWaitinglist(req.body, req, res, next);
 });
 
 app.get('/addToWaitinglist', (req, res, next) => {
+  // in case the call was redirected via login, we get called with "get"
   const body = req.session.previousBody;
   if (!body) { return next(); }
   delete req.session.previousBody;

--- a/softwerkskammer/lib/groups/views/get.pug
+++ b/softwerkskammer/lib/groups/views/get.pug
@@ -22,12 +22,12 @@ block content
           a.btn.btn-default(href=webcalURL, title=t('activities.export_subscribe')): i.fa.fa-calendar.fa-fw
           if (accessrights.canEditGroup(group))
             a.btn.btn-default(href='/groups/edit/' + group.id, title=t('general.edit')): i.fa.fa-edit
-        h2 #{group.longName} 
-          small #{group.type} 
+        h2 #{group.longName}
+          small #{group.type}
       p
         strong
           | #{t('general.address')}:
-        | 
+        |
         a(href='mailto:' + group.id + '@softwerkskammer.org')
           | #{group.id}@softwerkskammer.org
   .row
@@ -54,6 +54,9 @@ block content
         h4 #{t('activities.upcoming_activities')}:
         +activityList(upcomingGroupActivities)
       +tagCloud
+      if (recentGroupActivities.length > 0)
+        h4 #{t('activities.recent_activities')}:
+        +activityList(recentGroupActivities)
       if (blogposts.length > 0)
          +blogposts-panel(blogposts)
 

--- a/softwerkskammer/lib/members/index.js
+++ b/softwerkskammer/lib/members/index.js
@@ -159,14 +159,10 @@ app.post('/submit', (req, res, next) => {
   async.parallel(
     [
       callback => {
-        // we need this helper function (in order to have a closure?!)
-        const validityChecker = (nickname, cb) => membersService.isValidNickname(nickname, cb);
-        validation.checkValidity(req.body.previousNickname, req.body.nickname, validityChecker, req.i18n.t('validation.nickname_not_available'), callback);
+        validation.checkValidity(req.body.previousNickname, req.body.nickname, membersService.isValidNickname, req.i18n.t('validation.nickname_not_available'), callback);
       },
       callback => {
-        // we need this helper function (in order to have a closure?!)
-        const validityChecker = (email, cb) => membersService.isValidEmail(email, cb);
-        validation.checkValidity(req.body.previousEmail, req.body.email, validityChecker, req.i18n.t('validation.duplicate_email'), callback);
+        validation.checkValidity(req.body.previousEmail, req.body.email, membersService.isValidEmail, req.i18n.t('validation.duplicate_email'), callback);
       },
       callback => {
         const errors = validation.isValidForMember(req.body);

--- a/softwerkskammer/testutil/universalTestHelper.js
+++ b/softwerkskammer/testutil/universalTestHelper.js
@@ -10,7 +10,7 @@ module.exports = function universalTestHelper(defaultLanguage) {
     const initI18N = beans.get('initI18N');
 
     return {
-      createApp: params => { /* id, member, middlewares, baseurl, secureByMiddlewares, sessionID */
+      createApp: params => { /* id, member, middlewares, baseurl, secureByMiddlewares, sessionID, sessionCaptureCallback */
         const atts = params || {};
         const app = express();
         app.locals.pretty = true;
@@ -32,6 +32,12 @@ module.exports = function universalTestHelper(defaultLanguage) {
         }
         if (atts.user) {
           app.use(userStub(atts.user));
+        }
+        if (atts.sessionCaptureCallback) {
+          app.use((req, res, next) => {
+            atts.sessionCaptureCallback(req.session);
+            next();
+          });
         }
         app.use(beans.get('accessrights'));
         (atts.secureByMiddlewares || []).forEach(middleware => {


### PR DESCRIPTION
In order to be able to quickly determine whether a group is active (even when they don't announce upcoming activities yet) the group page now displays the 5 most recent activities below the tag cloud.
Also, I added some tests for uncovered code.