### PR TITLE
Add link to blog entry to activity actions header

### DIFF
--- a/locales/translation-de.json
+++ b/locales/translation-de.json
@@ -12,6 +12,7 @@
     "address_suffix": "Adress-Suffix",
     "already_registered": "SoCraTes only",
     "billing_address": "Rechnungsanschrift",
+    "blog_entry": "Blogartikel zur Aktivität",
     "count": "Anzahl",
     "count_participants_interval": "(0){Bislang gibt es keine Teilnahmezusagen.};(1){Bislang hat ein Mitglied seine Teilnahme zugesagt.};(2-inf){Bislang haben {{count}} Mitglieder ihre Teilnahme zugesagt.}",
     "create": "Aktivität anlegen",

--- a/locales/translation-en.json
+++ b/locales/translation-en.json
@@ -12,6 +12,7 @@
     "address_suffix": "Address-Suffix",
     "already_registered": "You are already registered.",
     "billing_address": "Billing address",
+    "blog_entry": "Blog article for activity",
     "count": "Count",
     "count_participants_interval": "(0){So far, there are no participants.};(1){So far, there is one participant.};(2-inf){So far, there are {{count}} participants.}",
     "create": "Create activity",

--- a/softwerkskammer/lib/activities/activity.js
+++ b/softwerkskammer/lib/activities/activity.js
@@ -142,7 +142,7 @@ class Activity {
   }
 
   blogEntryUrl() {
-    return `${this.assignedGroup()}/blog_${this.startMoment().format('YYYY-MM-DD')}_${Renderer.normalize(this.url())}`;
+    return `${this.assignedGroup()}/blog_${this.startMoment().format('YYYY-MM-DD')}_${Renderer.normalize(this.title())}`;
   }
 
   // Resources

--- a/softwerkskammer/lib/activities/activity.js
+++ b/softwerkskammer/lib/activities/activity.js
@@ -141,6 +141,10 @@ class Activity {
     this.group = groups.find(group => group.id === this.assignedGroup());
   }
 
+  blogEntryUrl() {
+    return `${this.assignedGroup()}/blog_${this.startMoment().format('YYYY-MM-DD')}_${Renderer.normalize(this.url())}`;
+  }
+
   // Resources
 
   resources() {

--- a/softwerkskammer/lib/activities/views/get.pug
+++ b/softwerkskammer/lib/activities/views/get.pug
@@ -19,6 +19,7 @@ block content
           img(height='80px', src='/qrcode?url=' + encodeURIComponent(activity.fullyQualifiedUrl()))
         .btn-group.pull-right
           a.btn.btn-default(href='/activities/ical/' + encodeURIComponent(activity.url()), title=t('activities.export')): i.fa.fa-calendar.fa-fw
+          a.btn.btn-default(href='/wiki/' + activity.blogEntryUrl(), title=t('activities.blog_entry')): i.fa.fa-rss.fa-fw
           if (accessrights.canCreateActivity())
             a.btn.btn-default(href='/activities/newLike/' + encodeURIComponent(activity.url()), title=t('activities.new_copy')): i.fa.fa-copy.fa-fw
           if (accessrights.canEditActivity(activity))

--- a/softwerkskammer/test/activities/activity_object_test.js
+++ b/softwerkskammer/test/activities/activity_object_test.js
@@ -2,6 +2,8 @@
 
 const expect = require('must-dist');
 
+const moment = require('moment');
+
 const Activity = require('../../testutil/configureForTest').get('beans').get('activity');
 
 // TODO Activity.fillFromUI with null/undefined in startDate, startTime, endDate, endTime
@@ -61,6 +63,28 @@ describe('Activity', () => {
       url: 'myURL'
     });
     expect(activity.colorFrom(null)).to.equal('#353535');
+  });
+
+  describe('blogEntryUrl', () => {
+    it('uses group id, date, and url to compose url', () => {
+      const activity = new Activity({
+        assignedGroup: 'mygroup',
+        url: 'my-activity',
+        startUnix: moment('20171120', 'YYYYMMDD').unix()
+      });
+
+      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activity');
+    });
+
+    it('replaces whitespaces in url with hyphens', () => {
+      const activity = new Activity({
+        assignedGroup: 'mygroup',
+        url: 'my activity',
+        startUnix: moment('20171120', 'YYYYMMDD').unix()
+      });
+
+      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activity');
+    });
   });
 });
 

--- a/softwerkskammer/test/activities/activity_object_test.js
+++ b/softwerkskammer/test/activities/activity_object_test.js
@@ -76,14 +76,14 @@ describe('Activity', () => {
       expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activity');
     });
 
-    it('replaces whitespaces in url with hyphens', () => {
+    it('replaces special characters in url with same characters', () => {
       const activity = new Activity({
         assignedGroup: 'mygroup',
-        url: 'my activity',
+        url: 'my activityÄÖÜ',
         startUnix: moment('20171120', 'YYYYMMDD').unix()
       });
 
-      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activity');
+      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activityaou');
     });
   });
 });

--- a/softwerkskammer/test/activities/activity_object_test.js
+++ b/softwerkskammer/test/activities/activity_object_test.js
@@ -66,24 +66,35 @@ describe('Activity', () => {
   });
 
   describe('blogEntryUrl', () => {
-    it('uses group id, date, and url to compose url', () => {
+    it('uses group id, date, and title to compose url', () => {
       const activity = new Activity({
         assignedGroup: 'mygroup',
-        url: 'my-activity',
+        title: 'my-activity',
         startUnix: moment('20171120', 'YYYYMMDD').unix()
       });
 
       expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activity');
+
     });
 
-    it('replaces special characters in url with same characters', () => {
+    it('uses lower cased title', () => {
       const activity = new Activity({
         assignedGroup: 'mygroup',
-        url: 'my activityÄÖÜ',
+        title: 'Myactivity',
         startUnix: moment('20171120', 'YYYYMMDD').unix()
       });
 
-      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_my-activityaou');
+      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_myactivity');
+    });
+
+    it('replaces special characters in title with same characters', () => {
+      const activity = new Activity({
+        assignedGroup: 'mygroup',
+        title: '74. my activityÄÖÜ',
+        startUnix: moment('20171120', 'YYYYMMDD').unix()
+      });
+
+      expect(activity.blogEntryUrl()).to.equal('mygroup/blog_2017-11-20_74-my-activityaou');
     });
   });
 });


### PR DESCRIPTION
Adds a button in the actions header element that links to the
corresponding blog article. The scheme for the blog entry wiki page is

{groupid}/blog_{date of activity in ISO format}_{activity url suffix}.

Fixes #1302 