### PR TITLE
Handle non-existing collection in mapReduce

### DIFF
--- a/softwerkskammer/lib/activities/activitystore.js
+++ b/softwerkskammer/lib/activities/activitystore.js
@@ -141,7 +141,6 @@ module.exports = {
     const parameters = {out: {inline: 1}, scope: {memberId, groupIds}, query, jsMode: true};
 
     persistence.mapReduce(map, reduce, parameters, (err, collection) => {
-      if (err && err.errmsg === 'ns doesn\'t exist') { return callback(null, []); } // no mongostore available -> nevermind
       if (err) { return callback(err); }
       if (!collection || collection.length === 0) {
         return callback(null, []);

--- a/softwerkskammer/lib/persistence/persistence.js
+++ b/softwerkskammer/lib/persistence/persistence.js
@@ -80,7 +80,14 @@ module.exports = function (collectionName) {
     mapReduce: function mapReduce(map, reduce, options, callback) {
       performInDB((err, db) => {
         if (err) { return callback(err); }
-        db.collection(collectionName).mapReduce(map, reduce, options, callback);
+        db.listCollections({name: collectionName}).toArray((err1, names) => {
+          if (err1) { callback(err1); }
+          if (names.length === 0) {
+            callback(null, []);
+          } else {
+            db.collection(collectionName).mapReduce(map, reduce, options, callback);
+          }
+        });
       });
     },
 

--- a/softwerkskammer/test/persistence/persistence_test.js
+++ b/softwerkskammer/test/persistence/persistence_test.js
@@ -299,4 +299,19 @@ describe('The persistence store', () => {
       });
     });
   });
+
+  describe('when collection does not exist', () => {
+    beforeEach(clearStore);
+
+    describe('mapReduce', () => {
+      it('returns empty array', done => {
+        const R = require('ramda');
+        persistence.mapReduce(() => 'nothing', R.identity, {out: {inline: 1}}, (err, result) => {
+          expect(err).to.not.exist();
+          expect(result).to.be.empty();
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
The `MongoError` message when a collection does not exist seems to have changed in the recent Mongo-DB version (I'm running 3.6.2) so the special case check for the "ns doesn't exist" error doesn't work across different MongoDB versions. So I thought one might handle the case that a collection does not exist in an non-exceptional way.
As it might be a nice feature of `mapReduce` to handle the case that the collection being queried does not exist and `mapReduce` wasn't used elsewhere than `activitiesForGroupIdsAndRegisteredMemberId` I handled it inside `Persistance.mapReduce`.

While investigating this I also noticed that the test case
```javascript
describe('Activity application with DB - without activities -', () => {
  ...
```
only works when run after the other tests in `activities_for_groupids_test.js` because
```javascript
beforeEach(done => { // if this fails, you need to start your mongo DB
  persistence.drop(done);
});
```
fails when the underlying collection does not exist. Should I make another pull request for this (either moving the `describe` inside the other toplevel `describe` or ignoring the `err`-path of `persistance.drop`)?