### PR TITLE
Fix crash when there are no directories in the wiki Git repo

### DIFF
--- a/softwerkskammer/lib/wiki/gitmech.js
+++ b/softwerkskammer/lib/wiki/gitmech.js
@@ -133,7 +133,7 @@ module.exports = {
   lsdirs: function lsdirs(callback) {
     if (!workTree) { return callback(null, []); } // to make it run on dev systems
     return gitExec.command(['ls-tree', '--name-only', '-d', 'HEAD'], (err, data) => {
-      if (err || !data) { return callback(err); }
+      if (err) { return callback(err); }
       return callback(null, dataToLines(data));
     });
   },

--- a/softwerkskammer/test/wiki/gitmech_test.js
+++ b/softwerkskammer/test/wiki/gitmech_test.js
@@ -425,9 +425,9 @@ describe('the gitmech module', () => {
     it('"lsdirs" - converts the data to an array of single non empty lines', done => {
       sinon.stub(gitExec, 'command').callsFake((args, callback) => {
         if (args[0] === 'ls-tree') {
-          callback(null, 'andex.md\n' +
+          callback(null, 'andex\n' +
             '\n' +
-            'andreastest.md');
+            'andreastest');
         }
       });
       Git.lsdirs((err, lines) => {
@@ -437,12 +437,25 @@ describe('the gitmech module', () => {
       });
     });
 
-    it('"lsdirs" - handles errors correct', done => {
+    it('"lsdirs" - handles errors correctly', done => {
       sinon.stub(gitExec, 'command').callsFake((args, callback) => {
         if (args[0] === 'ls-tree') { callback(new Error()); }
       });
       Git.lsdirs(err => {
         expect(err).to.exist();
+        done();
+      });
+    });
+
+    it('"lsdirs" - converts the data to an array of single non empty lines', done => {
+      sinon.stub(gitExec, 'command').callsFake((args, callback) => {
+        if (args[0] === 'ls-tree') {
+          callback(null, '');
+        }
+      });
+      Git.lsdirs((err, lines) => {
+        expect(err).to.not.exist();
+        expect(lines).to.be.empty();
         done();
       });
     });


### PR DESCRIPTION
Prior to this commit, lsdirs called callback(null) when there were no
directories in the wiki Git repository which caused subsequent error
checks to pass even though the result was undefined. Now, an empty
array is returned instead.