### PR TITLE
Introduce Atom feed for group blog posts

### DIFF
--- a/locales/translation-de.json
+++ b/locales/translation-de.json
@@ -470,6 +470,7 @@
     "search": "Wiki durchsuchen",
     "searchresults": "Suchergebnis",
     "subwiki": "Subwiki",
+    "subscribe": "Abonnieren",
     "tooltip": {
       "gotopage": "Zur Seite."
     },

--- a/locales/translation-en.json
+++ b/locales/translation-en.json
@@ -482,6 +482,7 @@
     "search": "Search wiki",
     "searchresults": "Search Results",
     "subwiki": "Subwiki",
+    "subscribe": "Subscribe",
     "tooltip": {
       "gotopage": "Go to page."
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express": "4.16.2",
     "express-session": "1.15.6",
     "ezmlm-node": "1.2.3",
+    "feed": "1.1.1",
     "font-awesome": "4.7.0",
     "fullcalendar": "3.8.2",
     "glob": "7.1.2",

--- a/softwerkskammer/lib/groups/views/get.pug
+++ b/softwerkskammer/lib/groups/views/get.pug
@@ -4,6 +4,10 @@ include ../../wiki/views/wiki-mixins
 include ../../activities/views/activities-mixins
 include ../../../../commonComponents/pug/formComponents
 
+block head
+  if (blogposts.length > 0)
+    link(rel='alternate', type='application/atom+xml', href=blogpostsFeedUrl)
+
 block title
     | #{group.longName}
 
@@ -58,7 +62,7 @@ block content
         h4 #{t('activities.recent_activities')}:
         +activityList(recentGroupActivities)
       if (blogposts.length > 0)
-         +blogposts-panel(blogposts)
+         +blogposts-panel(blogposts, blogpostsFeedUrl)
 
 block scripts
   +tagCloudScript(users, group.color)

--- a/softwerkskammer/lib/site/views/credits.pug
+++ b/softwerkskammer/lib/site/views/credits.pug
@@ -86,6 +86,7 @@ block content
         +defItem('node-imagemagick', 'https://github.com/rsms/node-imagemagick', 'Ein Wrapper für die imagemagick Werkzeuge')
         +defItem('Image Magick', 'http://imagemagick.org/', 'Erzeugen, bearbeiten, kombinieren, konvertieren von Bitmaps')
         +defItem('i18next', 'http://i18next.com/', 'Internationalisierung')
+        +defItem('feed', 'https://github.com/jpmonette/feed', 'Erzeugung von Atom/RSS-Feeds')
 
     .col-md-4
       h2 Allgemeine Bibliotheken

--- a/softwerkskammer/lib/wiki/views/wiki-mixins.pug
+++ b/softwerkskammer/lib/wiki/views/wiki-mixins.pug
@@ -1,5 +1,10 @@
-mixin blogposts-panel(posts)
-  h4 #{t('wiki.blogposts')}:
+mixin blogposts-panel(posts, feedUrl)
+  div
+    .btn-group.pull-right
+      a.btn.btn-default.btn-xs(href=feedUrl)
+        i.fa.fa-rss
+        | &nbsp;#{t('wiki.subscribe')}
+    h4 #{t('wiki.blogposts')}:
   each post in posts
     .panel.panel-default
       .panel-heading

--- a/softwerkskammer/lib/wiki/wikiObjects.js
+++ b/softwerkskammer/lib/wiki/wikiObjects.js
@@ -41,6 +41,7 @@ class Blogpost {
     this.name = name;
     this.title = Renderer.firstTokentextOf(post).replace(/^(#|\s)*/, '');
     this.teaser = Renderer.secondTokentextOf(post);
+    this.post = post;
 
     const match = name.match(BLOG_ENTRY_REGEX);
     this.datestring = match && match[1];
@@ -56,6 +57,8 @@ class Blogpost {
   date() { return moment(this.datestring, 'YYYY-MM-DD'); }
 
   pureName() { return this.title; }
+
+  renderBody() { return Renderer.titleAndRenderedTail(this.post).body; }
 }
 
 class FileWithChangelist {

--- a/softwerkskammer/test/groups/groups_test.js
+++ b/softwerkskammer/test/groups/groups_test.js
@@ -12,6 +12,8 @@ const Group = beans.get('group');
 const Activity = beans.get('activity');
 const fakeListAdapter = beans.get('fakeListAdapter');
 const fieldHelpers = beans.get('fieldHelpers');
+const wikiObjects = beans.get('wikiObjects');
+const wikiService = beans.get('wikiService');
 
 const createApp = require('../../testutil/testHelper')('groupsApp').createApp;
 
@@ -198,6 +200,24 @@ describe('Groups application', () => {
         .expect(/Zweite Aktivität/, done);
     });
 
+  });
+
+  describe('group feed', () => {
+    it('renders blog posts as XML', done => {
+      sinon.stub(wikiService, 'getBlogpostsForGroup').callsFake((groupid, callback) => {
+        callback(null, [
+          new wikiObjects.Blogpost('blog_2018-01-02_foo', '#Foo\n\nTeaser 1'),
+          new wikiObjects.Blogpost('blog_2018-02-03_bar', '#Bar\n\nTeaser 2')
+        ]);
+      });
+      request(createApp())
+        .get('/GroupA/feed')
+        .expect('Content-Type', /xml/)
+        .expect(200)
+        .expect(/Foo/).expect(/Teaser 1/).expect(/blog_2018-01-02_foo/)
+        .expect(/Bar/).expect(/Teaser 2/).expect(/blog_2018-02-03_bar/)
+        .expect(/<\/feed>\s*$/, done);
+    });
   });
 
   describe('group creation', () => {

--- a/softwerkskammer/views/commonLayout.pug
+++ b/softwerkskammer/views/commonLayout.pug
@@ -8,6 +8,7 @@ html
     link(rel='apple-touch-icon', href='/img/apple-touch-icon-120x120-precomposed.png')
     link(rel='apple-touch-icon', href='/img/apple-touch-icon-152x152-precomposed.png')
     link(href='/stylesheets/screen.css', rel='stylesheet')
+    block head
 
     title
       block title


### PR DESCRIPTION
Can be subscribed to from a supported browser (using <link/> in HTML
head) or via a new Subscribe button on top of the blog posts panel.

<img width="544" alt="screen shot 2018-03-17 at 22 19 26" src="https://user-images.githubusercontent.com/214207/37560143-6a33df72-2a33-11e8-9f47-cd2af3f6a2f9.png">