### PR TITLE
Remove obsolete step from Wiki READMEs

### DIFF
--- a/socrates/lib/wiki/README.md
+++ b/socrates/lib/wiki/README.md
@@ -13,5 +13,5 @@ Setting up the wiki
 1. Create a directory for your local wiki (for example, /path/to/wiki)
 1. cd /path/to/wiki; git init
 1. touch foo; git add foo; git commit -a -m 'fake a HEAD so git is happy'
-1. Write down the absolute path to the directory inside "config/socrates-wikirepo-config.json". *Please be sure to remove the comment lines at the top of the file*.
+1. Write down the absolute path to the directory inside "config/socrates-wikirepo-config.json".
 1. Restart the server, log on and click on "wiki" 

--- a/softwerkskammer/lib/wiki/README.md
+++ b/softwerkskammer/lib/wiki/README.md
@@ -13,5 +13,5 @@ Setting up the wiki
 1. Create a directory for your local wiki (for example, /path/to/wiki)
 1. cd /path/to/wiki; git init
 1. touch foo; git add foo; git commit -a -m 'fake a HEAD so git is happy'
-1. Write down the absolute path to the directory inside "config/wikirepo-config.json". *Please be sure to remove the comment lines at the top of the file*
+1. Write down the absolute path to the directory inside "config/wikirepo-config.json".
 1. Restart the server, log on and click on "wiki" 


### PR DESCRIPTION
As of commit 245658c2 there are no comments in the example
configuration files anymore that have to be removed.