### PR TITLE
log the info returned by nodemailer

### DIFF
--- a/softwerkskammer/lib/mailsender/mailtransport.js
+++ b/softwerkskammer/lib/mailsender/mailtransport.js
@@ -44,9 +44,10 @@ function sendBulkMail(receiverEmailAddresses, subject, html, fromName, fromAddre
 
   if (callback) { return transport.sendMail(mailoptions, callback); }
 
-  transport.sendMail(mailoptions, err => {
+  transport.sendMail(mailoptions, (err, info) => {
     if (err) { return logger.error(err); }
     logger.info('Notification sent. Content: ' + JSON.stringify(mailoptions));
+    logger.info('Nodemailer send report: ' + JSON.stringify(info));
   });
 }
 

--- a/softwerkskammer/lib/mailsender/mailtransport.js
+++ b/softwerkskammer/lib/mailsender/mailtransport.js
@@ -47,7 +47,7 @@ function sendBulkMail(receiverEmailAddresses, subject, html, fromName, fromAddre
   transport.sendMail(mailoptions, (err, info) => {
     if (err) { return logger.error(err); }
     logger.info('Notification sent. Content: ' + JSON.stringify(mailoptions));
-    logger.info('Nodemailer send report: ' + JSON.stringify(info));
+    logger.info('Nodemailer sendMail report: ' + JSON.stringify(info));
   });
 }
 


### PR DESCRIPTION
From the [docs](https://nodemailer.com/usage/#sending-mail):

> If the message includes several recipients then the message is considered sent if at least one recipient is accepted 

We now also log the sent information provided in the callback to get more information from nodemailer to troubleshoot #1456