### PR TITLE
Link zum Abmelden in Einladungsmails

### DIFF
--- a/softwerkskammer/lib/authentication/index.js
+++ b/softwerkskammer/lib/authentication/index.js
@@ -231,11 +231,21 @@ function setupUserPass(app1) {
 
 const app = misc.expressAppIn(__dirname);
 
-app.get("/logout", (req, res) => {
-  req.logout();
+app.get("/logout", (req, res, next) => {
+  req.logout(function (err) {
+    if (err) {
+      return next(err);
+    }
+    res.redirect("/");
+  });
   if (req.isAuthenticated && req.isAuthenticated()) {
     logger.info("Had to log out twice. IE problem?" + (req.user ? " - User was: " + req.user.authenticationId : ""));
-    req.logout();
+    req.logout(function (err) {
+      if (err) {
+        return next(err);
+      }
+      res.redirect("/");
+    });
   }
   res.redirect("/goodbye.html");
 });

--- a/softwerkskammer/lib/mailsender/mailsenderService.js
+++ b/softwerkskammer/lib/mailsender/mailsenderService.js
@@ -55,10 +55,16 @@ module.exports = {
     const message = new Message();
     message.setSubject("Einladung: " + activity.title());
     message.setMarkdown(activityMarkdown(activity, language));
-    message.addToButtons({
-      text: "Zur Aktivität",
-      url: misc.toFullQualifiedUrl("activities", encodeURIComponent(activity.url())),
-    });
+    message.addToButtons([
+      {
+        text: "Zur Aktivität",
+        url: misc.toFullQualifiedUrl("activities", encodeURIComponent(activity.url())),
+      },
+      {
+        text: "Gruppe verlassen",
+        url: misc.toFullQualifiedUrl("members", "edit/"),
+      },
+    ]);
     return {
       message,
       regionalgroups,

--- a/softwerkskammer/lib/members/index.js
+++ b/softwerkskammer/lib/members/index.js
@@ -109,6 +109,12 @@ app.get("/edit/:nickname", async (req, res, next) => {
   });
 });
 
+app.get("/edit/", async (req, res) => {
+  if (req.user && req.user.member) {
+    res.redirect("/members/edit/" + encodeURIComponent(req.user.member.nickname()));
+  }
+});
+
 app.post("/delete", async (req, res) => {
   const nickname = req.body.nickname;
   if (!res.locals.accessrights.canDeleteMemberByNickname(nickname)) {


### PR DESCRIPTION
@signed und ich haben eine (minimale) Umsetzung von #1495 gebaut.

Diskussionwürdige Punkte:
* wir haben im Menü erst Mal den Link nicht von `members/edit/<nickname>` auf `members/edit/` geändert: sonst müsste man konsequenterweise auch den Link für "Profile ansehen" anpassen
* den Hinweis aufs Abmelden haben wir per Button ins Einladungsmails gelöst, da dies die einfachste Lösung war. Die "schöneren" Lösungen hatten für uns  zu viele mögliche Seiteneffekte (z. B. Links in Mail, in denen das nicht passt, falsche Reihenfolge von Buttons, ...)
* was wir noch nicht geprüft haben: was ist, wenn ein Member den Nickname `edit` hat? Kann ich aber die Tage nochmal ausprobieren.

fixes #1495